### PR TITLE
Add support for nested models

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,10 +352,9 @@ pytest
 `pydanclick` doesn't support (yet!):
 
 - Pydantic v1
-- Nested models
-- Container types (tuples, lists, dicts) or other complex types
-- Converting fields to arguments, instead of options
-- Some union types won't work
+- converting fields to arguments, instead of options
+- fields annotated with union of Pydantic models can only be used with JSON inputs, instead of properly merging all sub-fields
+- custom argument validators
 
 Other missing features:
 
@@ -363,6 +362,8 @@ Other missing features:
 - Specifying all field-specific options directly in the Pydantic model (would allow easier re-use)
 - Most Click features should be supported out-of-the-box through the `extra_options` parameter. However, most of them aren't tested
 - Click and Pydantic both include validation logic. In particular, Click support custom `ParamType`, validation callbacks and `BadParameter` errors: it's not clear if we want to fully rely on Pydantic or on Click or on a mixture of both
+- populating Pydantic fields from existing options or arguments (combined with `exclude`, it will provide a complete escape hatch to bypass Pydantclick when needed)
+- attaching Pydanclick arguments directly to the model class, to avoid duplication when re-using a model in multiple commands
 
 <!--  --8<-- [end:limitations] -->
 

--- a/docs/examples/complex.md
+++ b/docs/examples/complex.md
@@ -1,4 +1,4 @@
-# Complex Example
+# Example: Multiple Models
 
 In this second example, we use multiple models in a single command:
 

--- a/docs/examples/complex_types.md
+++ b/docs/examples/complex_types.md
@@ -1,0 +1,39 @@
+# Example: Complex Types
+
+Complex container types such as lists or dicts are supported: they must be passed as JSON strings, and will be parsed by Pydantic through the `TypeAdapter.validate_json` method.
+Consider the following Pydantic model:
+
+```python
+--8<--
+complex_types.py
+--8<--
+```
+
+It can be ran with:
+
+```shell
+python examples/complex_types.py \
+    --image foo \
+    --mounts '[["tmpfs", "/foo/bar", "foo/"], ["bind", ".", "foo/"]]' \
+    --ports '{"80":80, "8888":8888}'
+```
+
+_Pay attention to single quotes versus double quotes: quotes are required around the JSON strings to prevent shell extension, and JSON strings **must** use double quotes._
+
+Such types as marked as `JSON STRING` in the Click documentation:
+
+```shell
+~ python examples/complex_types.py --help                                                                                                                        <aws:tooling>
+Usage: complex_types.py [OPTIONS]
+
+  A fake Docker client.
+
+Options:
+  --image TEXT          image name  [required]
+  --mounts JSON STRING  how to mount data on your container, as triples
+                        `(mount_type, src, dst)`
+  --ports JSON STRING   port binding
+  --help                Show this message and exit.
+```
+
+As of now, Pydanclick doesn't provide a mechanism to override this.

--- a/docs/examples/nested.md
+++ b/docs/examples/nested.md
@@ -1,0 +1,28 @@
+# Nested Example
+
+In this third example, our Pydantic model itself contains Pydantic models. Nested fields can be overridden from the command-line:
+
+```python
+--8<--
+nested.py
+--8<--
+```
+
+```shell
+~ python examples/nested.py --help                                                                                                                               <aws:tooling>
+Usage: nested.py [OPTIONS]
+
+Options:
+  --foo-a INTEGER       first letter
+  --foo-b / --no-foo-b  second letter
+  --bar-a FLOAT         an argument
+  --bar-b TEXT          another one
+  --baz-c [a|b]         third letter
+  --help                Show this message and exit.
+```
+
+Some observations:
+
+- you can `rename` any field by using its _dotted name_ (here, `bar.baz`)
+- same notation can be used for `exclude`, `shorten`, `extra_options`
+- when a field is renamed, all its subfields are renamed, too

--- a/docs/examples/simple.md
+++ b/docs/examples/simple.md
@@ -26,5 +26,5 @@ Options:
 You can notice that:
 
 - fields without default values are marked as `required`
-- contraints are properly recognized by Click
+- constraints are properly recognized by Click
 - boolean fields are converted to boolean flags, as recommended by Click

--- a/examples/complex_types.py
+++ b/examples/complex_types.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+from typing import Dict, List, Literal, Tuple
+
+import click
+from pydantic import BaseModel, Field
+
+from pydanclick import from_pydantic
+
+
+class RunConfig(BaseModel):
+    """Configure how to run your container.
+
+    Attributes:
+        image: image name
+        mounts: how to mount data on your container, as triples `(mount_type, src, dst)`
+        ports: port binding
+    """
+
+    image: str
+    mounts: List[Tuple[Literal["bind", "volume", "tmpfs"], Path, Path]] = Field(default_factory=list)
+    ports: Dict[int, int] = Field(default_factory=dict)
+
+
+@click.command()
+@from_pydantic("config", RunConfig)
+def cli(config: RunConfig):
+    """A fake Docker client."""
+    # Here, we receive an already validated Pydantic object.
+    click.echo(config.model_dump_json(indent=2))
+
+
+if __name__ == "__main__":
+    cli()

--- a/examples/nested.py
+++ b/examples/nested.py
@@ -1,0 +1,64 @@
+from typing import Literal
+
+import click
+from pydantic import BaseModel, Field
+
+from pydanclick import from_pydantic
+
+
+class Foo(BaseModel):
+    """Foo.
+
+    Attributes:
+        a: first letter
+        b: second letter
+    """
+
+    a: int = 1
+    b: bool = True
+
+
+class Baz(BaseModel):
+    """Baz.
+
+    Attributes:
+        c: third letter
+    """
+
+    c: Literal["a", "b"] = "a"
+
+
+class Bar(BaseModel):
+    """Bar.
+
+    Attributes:
+        a: an argument
+        b: another one
+        baz: a third one
+    """
+
+    a: float = 0.1
+    b: str = "b"
+    baz: Baz = Field(default_factory=Baz)
+
+
+class Obj(BaseModel):
+    """Obj.
+
+    Attributes:
+        foo: foo attribute
+        bar: bar attribute
+    """
+
+    foo: Foo = Field(default_factory=Foo)
+    bar: Bar = Field(default_factory=Bar)
+
+
+@click.command()
+@from_pydantic("obj", Obj, rename={"bar.baz": "baz"})
+def cli(obj: Obj):
+    click.echo(obj.model_dump_json(indent=2))
+
+
+if __name__ == "__main__":
+    cli()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,8 +11,10 @@ nav:
   - Home: index.md
   - API Reference: api_reference.md
   - Examples:
-      - Simple: examples/simple.md
-      - Complex: examples/complex.md
+      - Simple Example: examples/simple.md
+      - Multiple Models: examples/complex.md
+      - Nested Models: examples/nested.md
+      - Complex Types: examples/complex_types.md
   - Contributing: contributing.md
 plugins:
   - search

--- a/pydanclick/command.py
+++ b/pydanclick/command.py
@@ -1,0 +1,69 @@
+"""Utilities to work with Click commands and options."""
+
+from typing import Any, Callable, List, Optional, TypeVar, Union
+
+import click
+
+T = TypeVar("T")
+
+
+def add_options(
+    __f_or_opts: Union[Callable[..., Any], List[click.Option]], options: Optional[List[click.Option]] = None
+) -> Callable[..., Any]:
+    """Add options to a Click command.
+
+    Given `options` a list of `click.Option` instances, it can either be used as a decorator:
+
+    ```python
+    @click.command()
+    @add_options(options)
+    def cli(...):
+        pass
+    ```
+
+    Or called directly on a function:
+
+    ```python
+    command = add_options(command, options)
+    ```
+
+    Args:
+        __f_or_opts: if used as a decorator, list of options to add. Otherwise, a callable or a `click.Command` to add
+            the options to
+        options: list of options to add (if called directly on a function)
+
+    Returns:
+        either a decorator or the callable/command with the new options added
+    """
+    if callable(__f_or_opts):
+        if options is None:
+            raise ValueError("No options specified.")
+        return _add_options(__f_or_opts, options)
+
+    def wrapper(__f: Callable[..., T]) -> Callable[..., T]:
+        return add_options(__f, __f_or_opts)
+
+    return wrapper
+
+
+def _add_options(f: Callable[..., Any], options: List[click.Option]) -> Callable[..., Any]:
+    """Add Click options to a callable or command.
+
+    This is basically a copy of what the `@click.option()` decorator does (i.e. if `f` isn't a `click.Command`, add its
+    parameters to a hidden `__click_params__` attribute).
+
+    Args:
+        f: callable or `click.Command` instance. It will be modified in-place.
+        options: list of options to add to `f`
+
+    Returns:
+        the same callable or command, returned for convenience
+    """
+    ordered_options = reversed(options)
+    if isinstance(f, click.Command):
+        f.params.extend(ordered_options)
+    else:
+        if not hasattr(f, "__click_params__"):
+            f.__click_params__ = []  # type: ignore[attr-defined]
+        f.__click_params__.extend(ordered_options)  # type: ignore[attr-defined]
+    return f

--- a/pydanclick/main.py
+++ b/pydanclick/main.py
@@ -1,54 +1,13 @@
-import datetime
 import functools
-from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Sequence,
-    Type,
-    TypedDict,
-    TypeVar,
-    Union,
-    get_args,
-    get_origin,
-)
-from uuid import UUID
+from typing import Any, Callable, Dict, Literal, Optional, Sequence, Type, TypeVar
 
-import click
-from annotated_types import Ge, Gt, Le, Lt, SupportsGe, SupportsGt, SupportsLe, SupportsLt
 from pydantic import BaseModel
-from pydantic.fields import FieldInfo
-from pydantic_core import PydanticUndefined
 
-# Can't use `types.NoneType`, as it was only introduced in Python 3.10
-NoneType = type(None)
+from pydanclick.command import add_options
+from pydanclick.model import convert_to_click
+from pydanclick.types import _ParameterKwargs
 
 T = TypeVar("T")
-
-
-class _ParameterKwargs(TypedDict, total=False):
-    """Represent valid parameters for `click.option()`."""
-
-    param_decls: Optional[Sequence[str]]
-    show_default: Union[bool, str, None]
-    prompt: Union[bool, str]
-    confirmation_prompt: Union[bool, str]
-    prompt_required: bool
-    hide_input: bool
-    is_flag: Optional[bool]
-    flag_value: Optional[Any]
-    multiple: bool
-    count: bool
-    allow_from_autoenv: bool
-    type: Optional[Union[click.ParamType, Any]]
-    help: Optional[str]
-    hidden: bool
-    show_choices: bool
-    show_envvar: bool
 
 
 def from_pydantic(
@@ -58,7 +17,7 @@ def from_pydantic(
     exclude: Sequence[str] = (),
     rename: Optional[Dict[str, str]] = None,
     shorten: Optional[Dict[str, str]] = None,
-    prefix: str = "",
+    prefix: str | None = None,
     parse_docstring: bool = True,
     docstring_style: Literal["google", "numpy", "sphinx"] = "google",
     extra_options: Optional[Dict[str, _ParameterKwargs]] = None,
@@ -81,256 +40,24 @@ def from_pydantic(
     Returns:
         a decorator that adds options to a function
     """
-    excluded_fields = set(exclude)
-    fields = {
-        field_name: field for field_name, field in model.model_fields.items() if field_name not in excluded_fields
-    }
-    renamed_fields = rename if rename is not None else {}
-    shortened_fields = shorten if shorten is not None else {}
-    extra_options = extra_options if extra_options is not None else {}
-    doc = _parse_docstring(model, docstring_style=docstring_style) if parse_docstring else {}
+    options, validator = convert_to_click(
+        model,
+        exclude=exclude,
+        rename=rename,
+        shorten=shorten,
+        prefix=prefix,
+        parse_docstring=parse_docstring,
+        docstring_style=docstring_style,
+        extra_options=extra_options,
+    )
 
     def wrapper(f: Callable[..., T]) -> Callable[..., T]:
+        @add_options(options)
         @functools.wraps(f)
-        def wrapped(**kwargs: Any) -> Any:
-            raw_model = {field: kwargs.pop(field) for field in fields if field in kwargs}
-            kwargs[__var] = model.model_validate(raw_model)
+        def wrapped(**kwargs: Any) -> T:
+            kwargs[__var] = validator(kwargs)
             return f(**kwargs)
 
-        # Use `reversed` to preserve order
-        for field_name, field in reversed(fields.items()):
-            option_name = renamed_fields.get(field_name)
-            short_name = shortened_fields.get(field_name)
-            wrapped = _get_option_from_field(
-                field_name,
-                field,
-                prefix=prefix,
-                documentation=doc,
-                option_name=option_name,
-                short_name=short_name,
-                option_kwargs=extra_options.get(field_name),
-            )(wrapped)
-        return wrapped
+        return wrapped  # type: ignore[no-any-return]
 
     return wrapper
-
-
-def _get_option_from_field(
-    field_name: str,
-    field: FieldInfo,
-    prefix: str = "",
-    documentation: Optional[Dict[str, str]] = None,
-    option_name: Optional[str] = None,
-    short_name: Optional[str] = None,
-    option_kwargs: Optional[_ParameterKwargs] = None,
-) -> Callable[[Callable[..., T]], Callable[..., T]]:
-    """Convert a Pydantic field to a Click option function.
-
-    Note that it doesn't return a `click.Option` object, but rather a decorator, as created by `click.option()`.
-
-    Args:
-        field_name: Pydantic field name (usually in snake_case)
-        field: field to convert
-        prefix: prefix to add to the field name
-        documentation: help string for the option
-        option_name: name of the option (in kebab-case, starting with two dashes). If not provided, option name will be
-            `--{prefix}-{field-name}`, where `field-name` is the kebab-case version of `field_name`.
-        short_name: short name of the option (one dash and one letter)
-        option_kwargs: extra options to pass to `click.option`
-
-    Returns:
-
-    """
-    if documentation is None:
-        documentation = {}
-    param_decls = [field_name]
-    if option_name is None:
-        option_name = _get_option_name(field_name, is_boolean_flag=field.annotation is bool, prefix=prefix)
-    param_decls.append(option_name)
-    if short_name is not None:
-        param_decls.append(short_name)
-    kwargs = {
-        "type": _get_type_from_field(field),
-        "default": _get_default_value_from_field(field),
-        "required": field.is_required(),
-        "help": field.description or documentation.get(field_name, ""),
-    }
-    if option_kwargs is not None:
-        kwargs.update(option_kwargs)
-    return click.option(*param_decls, cls=click.Option, **kwargs)
-
-
-def _get_option_name(field_name: str, is_boolean_flag: bool = False, prefix: str = "") -> str:
-    """Convert a field name into a CLI option name.
-
-    Args:
-        field_name: field name, in snake_case
-        is_boolean_flag: whether the field is a boolean flag. If True, this will create two options `--{opt}/--no-{opt}`
-            as recommended by Click: https://click.palletsprojects.com/en/8.1.x/options/#boolean-flags
-        prefix: an optional prefix to add to the option name (it does not need to start or end with a dash)
-
-    Returns:
-        the option name, in kebab-case, with two dashes prepended and an optional prefix
-    """
-    base_option_name = field_name.replace("_", "-")
-    if prefix:
-        base_option_name = f"{prefix}-{base_option_name}"
-    if is_boolean_flag:
-        return f"--{base_option_name}/--no-{base_option_name}"
-    return f"--{base_option_name}"
-
-
-class _RangeDict(TypedDict, total=False):
-    """Represent arguments to `click.IntRange` or `click.FloatRange`."""
-
-    max: Union[SupportsLt, SupportsLe]
-    min: Union[SupportsGt, SupportsGe]
-    max_open: bool
-    min_open: bool
-
-
-def _get_range_from_metadata(metadata: List[Any]) -> _RangeDict:
-    """Convert Pydantic numerical constraints to keyword argumetns compatible with `IntRange` and `FloatRange`.
-
-    Args:
-        metadata: list of Pydantic constraints
-
-    Returns:
-        a dictionary
-    """
-    range_args: _RangeDict = {}
-    for constraint in metadata:
-        if isinstance(constraint, Le):
-            range_args["max"] = constraint.le
-            range_args["max_open"] = False
-        if isinstance(constraint, Lt):
-            range_args["max"] = constraint.lt
-            range_args["max_open"] = True
-        if isinstance(constraint, Ge):
-            range_args["min"] = constraint.ge
-            range_args["min_open"] = False
-        if isinstance(constraint, Gt):
-            range_args["min"] = constraint.gt
-            range_args["min_open"] = True
-    return range_args
-
-
-def _get_numerical_type(field: FieldInfo) -> click.ParamType:
-    """Convert a numerical field to a Click parameter type.
-
-    Converts Pydantic numerical constraints (e.g. `Field(gt=0)` or `Field(le=10)`) into a Click range type such as
-    `IntRange` or `FloatRange`. Unconstrained types result in `click.INT` or `click.FLOAT` types. Decimal types or any
-    non-integer numerical type will be treated as a float.
-
-    Args:
-        field: field to convert
-
-    Returns:
-        either `click.INT`, `click.FLOAT` or an instance of `click.IntRange` or `click.FloatRange`
-    """
-    range_args = _get_range_from_metadata(field.metadata)
-    if field.annotation is int:
-        if range_args:
-            return click.IntRange(**range_args)  # type: ignore[arg-type]
-        return click.INT
-    # Non-integer numerical types default to float
-    if range_args:
-        return click.FloatRange(**range_args)  # type: ignore[arg-type]
-    return click.FLOAT
-
-
-def _get_type_from_field(field: FieldInfo) -> click.ParamType:
-    """Get the Click type for a Pydantic field.
-
-    Pydantic and Click both define custom types for validating arguments. This function attempts to map Pydantic field
-    types to Click `ParamType` instances, on a best effort basis. Pydantic types may be stricted than their Click
-    counterparts: in that case, validation will happen when instantiating the Pydantic model, not when Click parses
-    the CLI arguments. When no equivalent is found, Click won't perform any validation and Pydantic will receive raw
-    strings.
-
-    Args:
-        field: field to convert
-
-    Returns:
-        a Click type
-    """
-    field_type = field.annotation
-    field_args = get_args(field_type)
-    field_origin = get_origin(field_type)
-    # TODO: handle annotated
-    # TODO: handle subclasses
-    if field_origin is Union and len(field_args) == 2 and NoneType in field_args and field.default is None:
-        # Optional types where None is only used as a default value can be safely treated as a
-        # non-optional type, since Click doesn't really distinguish between a strign with default value None from
-        # an actual str
-        field_type = next(field_arg for field_arg in field_args if field_arg is not None)
-    if field_type is str:
-        return click.STRING
-    elif field_type in (int, float):
-        return _get_numerical_type(field)
-    elif field_type is float:
-        return click.FLOAT
-    elif field_type is bool:
-        return click.BOOL
-    elif field_type is UUID:
-        return click.UUID
-    elif field_type is Path:
-        return click.Path(path_type=Path)
-    elif field_type in (datetime.datetime, datetime.date):
-        return click.DateTime()
-    elif field_origin is Literal:
-        # TODO: allow converting literal to feature switches
-        return click.Choice(field_args)
-    else:
-        # TODO: generate custom types: https://click.palletsprojects.com/en/8.1.x/api/#click.ParamType ?
-        # Default to None and let Pydantic handle the validation
-        custom_type = click.ParamType()
-        custom_type.name = str(field.annotation)
-        return custom_type
-
-
-def _get_default_value_from_field(field: FieldInfo) -> Union[Any, Callable[[], Any], None]:
-    """Return the default value of `field`.
-
-    Args:
-         field: Pydantic field
-
-    Returns:
-        either the default value or the default factory or None if field has no default
-    """
-    if field.default is not PydanticUndefined:
-        return field.default
-    elif field.default_factory is not None:
-        return field.default_factory
-    return None
-
-
-def _parse_docstring(
-    model_cls: Type[BaseModel], docstring_style: Literal["google", "numpy", "sphinx"] = "google"
-) -> Dict[str, str]:
-    """Parse the docstring of a `BaseModel` and returns a mapping from field name to their documentation.
-
-    Requires the optional dependency `griffe`. If it is not installed, return an empty dictionary.
-
-    Args:
-        model_cls: base model to parse
-        docstring_style: docstring style (see `griffe` documentation for details)
-
-    Returns:
-        a mapping from field name to their documentation. Only documented fields will be present
-    """
-    try:
-        from griffe.dataclasses import Docstring
-        from griffe.docstrings.dataclasses import DocstringAttribute, DocstringSectionAttributes
-    except ImportError:
-        return {}
-    docstring = Docstring(model_cls.__doc__ or "").parse(docstring_style)
-    fields = {}
-    for section in docstring:
-        if not isinstance(section, DocstringSectionAttributes):
-            continue
-        for attribute in section.value:
-            if not isinstance(attribute, DocstringAttribute):
-                continue
-            fields[attribute.name] = attribute.description
-    return fields

--- a/pydanclick/main.py
+++ b/pydanclick/main.py
@@ -17,7 +17,7 @@ def from_pydantic(
     exclude: Sequence[str] = (),
     rename: Optional[Dict[str, str]] = None,
     shorten: Optional[Dict[str, str]] = None,
-    prefix: str | None = None,
+    prefix: Optional[str] = None,
     parse_docstring: bool = True,
     docstring_style: Literal["google", "numpy", "sphinx"] = "google",
     extra_options: Optional[Dict[str, _ParameterKwargs]] = None,

--- a/pydanclick/model/__init__.py
+++ b/pydanclick/model/__init__.py
@@ -1,0 +1,5 @@
+"""Analyze a Pydantic model and turn it into Click options."""
+
+from pydanclick.model.model_conversion import convert_to_click
+
+__all__ = ("convert_to_click",)

--- a/pydanclick/model/docstrings.py
+++ b/pydanclick/model/docstrings.py
@@ -1,0 +1,46 @@
+"""Extract attribute documentation from docstrings."""
+
+from typing import Dict, Literal, Type
+
+from pydantic import BaseModel
+from typing_extensions import TypeAlias
+
+from pydanclick.types import FieldName
+
+DocstringStyle: TypeAlias = Literal["google", "numpy", "sphinx"]
+
+
+def parse_attribute_documentation(
+    model_cls: Type[BaseModel], docstring_style: DocstringStyle = "google"
+) -> Dict[FieldName, str]:
+    """Parse the docstring of a `BaseModel` and returns a mapping from field name to their documentation.
+
+    Requires the optional dependency `griffe`. If it is not installed, returns an empty dictionary.
+
+    Args:
+        model_cls: base model to parse
+        docstring_style: docstring style (see `griffe` documentation for details)
+
+    Returns:
+        a mapping from field name to their documentation. Only documented fields will be present
+    """
+    try:
+        import logging
+
+        from griffe.dataclasses import Docstring
+        from griffe.docstrings.dataclasses import DocstringAttribute, DocstringSectionAttributes
+
+        logging.getLogger(f"griffe.docstrings.{docstring_style}").disabled = True
+        logging.getLogger("griffe.agents.nodes").disabled = True
+    except ImportError:
+        return {}
+    docstring = Docstring(model_cls.__doc__ or "").parse(docstring_style)
+    fields = {}
+    for section in docstring:
+        if not isinstance(section, DocstringSectionAttributes):
+            continue
+        for attribute in section.value:
+            if not isinstance(attribute, DocstringAttribute):
+                continue
+            fields[FieldName(attribute.name)] = attribute.description
+    return fields

--- a/pydanclick/model/field_collection.py
+++ b/pydanclick/model/field_collection.py
@@ -1,0 +1,135 @@
+"""Collect fields from Pydantic models."""
+
+import dataclasses
+import re
+from typing import Any, Iterable, List, Literal, Optional, Tuple, Type, Union, get_args, get_origin
+
+from pydantic import BaseModel
+from pydantic.fields import FieldInfo
+from typing_extensions import TypeGuard
+
+from pydanclick.model.docstrings import parse_attribute_documentation
+from pydanclick.types import DottedFieldName, FieldName
+
+
+@dataclasses.dataclass
+class _Field:
+    """Represent a (possibly nested) field contained in a Pydantic model.
+
+    Attributes:
+        name: name of the field (without its parent)
+        dotted_name: dotted name of the field (i.e. field name and all its parent names, joined with dots). From a user
+            standpoint, this uniquely identifies the field within a nested model.
+        field_info: Pydantic `FieldInfo` object representing the field
+        documentation: help string for the field, if available
+        parents: list of parent names for the field
+    """
+
+    name: FieldName
+    dotted_name: DottedFieldName
+    field_info: FieldInfo
+    documentation: Optional[str] = None
+    parents: Tuple[FieldName, ...] = ()
+
+    @property
+    def is_boolean_flag(self) -> bool:
+        """Return True if the field represents boolean values."""
+        return self.field_info.annotation is bool
+
+
+def collect_fields(
+    obj: Type[BaseModel],
+    excluded_fields: Iterable[DottedFieldName] = frozenset(),
+    parse_docstring: bool = True,
+    docstring_style: Literal["google", "numpy", "sphinx"] = "google",
+) -> List[_Field]:
+    """Collect fields (including nested ones) from a Pydantic model.
+
+    Args:
+        obj: Pydantic model to collect fields from
+        excluded_fields: fields to exclude. To exclude nested fields, use their dotted names, i.e. the field name and
+            all its parent names, separated by dots
+        parse_docstring: if True, parse the model docstring and extract document for each field
+        docstring_style: docstring style of the model. Ignored if `parse_docstring=False`
+
+    Returns:
+        a mapping from field dotted names to field objects. Each field object contains the Pydantic `FieldInfo`, as well
+            as additional information, such as field parents, name of the argument mapped to the field, documentation
+            and so on. See `_Field` for details.
+    """
+    if excluded_fields:
+        excluded_pattern = r"^(" + "|".join(field.replace(".", "[.]") for field in excluded_fields) + r")\b"
+    else:
+        excluded_pattern = None
+    return [
+        option
+        for option in _collect_fields(obj, docstring_style=docstring_style, parse_docstring=parse_docstring)
+        if excluded_pattern is None or not re.search(excluded_pattern, option.dotted_name)
+    ]
+
+
+def _iter_union(field_type: Any) -> list[Type[Any]]:
+    """Iterate over the types of a union.
+
+    Args:
+        field_type: union type to iterate over. If not a union, return an empty list.
+
+    Returns:
+        list of types in the union, if any
+    """
+    if get_origin(field_type) is Union:
+        return list(get_args(field_type))
+    return []
+
+
+def _is_pydantic_model(model: Any) -> TypeGuard[Type[BaseModel]]:
+    """Return True if `model` is a Pydantic `BaseModel` class."""
+    return isinstance(model, type) and issubclass(model, BaseModel)
+
+
+def _collect_fields(
+    obj: Type[BaseModel] | FieldInfo,
+    name: FieldName = "",  # type: ignore[assignment]
+    parents: tuple[FieldName, ...] = (),
+    documentation: str | None = None,
+    parse_docstring: bool = True,
+    docstring_style: Literal["google", "numpy", "sphinx"] = "google",
+) -> Iterable[_Field]:
+    """Recursively iterate over fields from a Pydantic model."""
+    if _is_pydantic_model(obj) or _is_pydantic_model(getattr(obj, "annotation", None)):
+        model: Type[BaseModel]
+        model = obj if _is_pydantic_model(obj) else obj.annotation  # type: ignore[assignment, union-attr]
+        docstrings = parse_attribute_documentation(model, docstring_style=docstring_style) if parse_docstring else {}
+        for field_name, field in model.model_fields.items():
+            field_name = FieldName(field_name)
+            documentation = docstrings.get(field_name, None)
+            yield from _collect_fields(
+                field,
+                name=field_name,
+                parents=(*parents, field_name),
+                documentation=documentation,
+                parse_docstring=parse_docstring,
+            )
+    elif isinstance(obj, FieldInfo):
+        if not name:
+            raise ValueError(f"Can't automatically infer a name from a field: {obj}")
+        for annotation in _iter_union(obj.annotation):
+            if _is_pydantic_model(annotation):
+                yield from _collect_fields(
+                    annotation,
+                    name=name,
+                    parents=parents,
+                    documentation=documentation,
+                    parse_docstring=parse_docstring,
+                )
+        # TODO: exclude base models from the union
+        dotted_name = DottedFieldName(".".join(parents))
+        yield _Field(
+            name=name,
+            dotted_name=dotted_name,
+            parents=parents,
+            field_info=obj,
+            documentation=documentation,
+        )
+    else:
+        raise TypeError(f"Can't process {type(obj)}: {obj} is neither a `BaseModel`, nor a `FieldInfo`")

--- a/pydanclick/model/field_collection.py
+++ b/pydanclick/model/field_collection.py
@@ -68,7 +68,7 @@ def collect_fields(
     ]
 
 
-def _iter_union(field_type: Any) -> list[Type[Any]]:
+def _iter_union(field_type: Any) -> List[Type[Any]]:
     """Iterate over the types of a union.
 
     Args:
@@ -88,10 +88,10 @@ def _is_pydantic_model(model: Any) -> TypeGuard[Type[BaseModel]]:
 
 
 def _collect_fields(
-    obj: Type[BaseModel] | FieldInfo,
+    obj: Union[Type[BaseModel], FieldInfo],
     name: FieldName = "",  # type: ignore[assignment]
-    parents: tuple[FieldName, ...] = (),
-    documentation: str | None = None,
+    parents: Tuple[FieldName, ...] = (),
+    documentation: Optional[str] = None,
     parse_docstring: bool = True,
     docstring_style: Literal["google", "numpy", "sphinx"] = "google",
 ) -> Iterable[_Field]:

--- a/pydanclick/model/field_conversion.py
+++ b/pydanclick/model/field_conversion.py
@@ -86,7 +86,9 @@ def _get_base_option_name(
 
 
 def _convert_to_valid_prefix(name: str) -> str:
-    return ("--" + name.removesuffix("-").removeprefix("-").removeprefix("-")) if name else name
+    if not name:
+        return name
+    return "--" + strip_option_name(name)
 
 
 def get_option_name(
@@ -125,7 +127,9 @@ def get_option_name(
     if not is_boolean or "/" in base_name:
         return base_name
     else:
-        return OptionName(f"{base_name}/--no-{base_name.removeprefix('--')}")
+        if base_name.startswith("--"):
+            base_name = base_name[2:]
+        return OptionName(f"--{base_name}/--no-{base_name}")
 
 
 def _get_option_from_field(

--- a/pydanclick/model/field_conversion.py
+++ b/pydanclick/model/field_conversion.py
@@ -1,0 +1,180 @@
+"""Convert Pydantic fields to Click options."""
+
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
+
+import click
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
+
+from pydanclick.model.field_collection import _Field
+from pydanclick.model.type_conversion import _get_type_from_field
+from pydanclick.types import ArgumentName, DottedFieldName, OptionName, _ParameterKwargs
+from pydanclick.utils import kebab_case_to_snake_case, snake_case_to_kebab_case, strip_option_name
+
+T = TypeVar("T")
+
+
+def convert_fields_to_options(
+    fields: List[_Field],
+    prefix: Optional[str] = None,
+    aliases: Optional[Dict[DottedFieldName, OptionName]] = None,
+    shorten: Optional[Dict[DottedFieldName, OptionName]] = None,
+    extra_options: Optional[Dict[DottedFieldName, _ParameterKwargs]] = None,
+) -> Tuple[Dict[ArgumentName, DottedFieldName], List[click.Option]]:
+    """Convert Pydantic fields to Click options.
+
+    Args:
+        fields: fields to convert
+        prefix: prefix to add to each option name, if any
+        aliases: custom option names for specific fields, as a mapping from dotted field names to option names
+        shorten: short option names for specific fields, as a mapping from dotted field names to 1-letter option names
+        extra_options: extra options to pass to `click.Option` for specific fields, as a mapping from dotted field names
+            to option dictionary
+
+    Returns:
+        a pair `(qualified_names, options)` where `qualified_names` is a mapping from argument names to dotted field
+            names and `options` is a list of `click.Option` objects. When calling a command, Click will use these
+            options to parse the command line arguments, and will return a mapping from argument names to values.
+    """
+    aliases = aliases or {}
+    aliases = {dotted_name: OptionName(_convert_to_valid_prefix(alias)) for dotted_name, alias in aliases.items()}
+    option_prefix = _convert_to_valid_prefix(prefix) if prefix is not None else ""
+    argument_prefix = kebab_case_to_snake_case(strip_option_name(option_prefix)) + "_" if option_prefix else ""
+    shorten = shorten or {}
+    extra_options = extra_options or {}
+    options = []
+    qualified_names = {}
+    for field in fields:
+        argument_name = ArgumentName(argument_prefix + "_".join(field.parents))
+        option = _get_option_from_field(
+            argument_name=argument_name,
+            option_name=get_option_name(
+                field.dotted_name, aliases=aliases, is_boolean=field.is_boolean_flag, prefix=option_prefix
+            ),
+            field_info=field.field_info,
+            documentation=field.field_info.description or field.documentation,
+            short_name=shorten.get(field.dotted_name, None),
+            option_kwargs=extra_options.get(field.dotted_name, {}),
+        )
+        options.append(option)
+        qualified_names[argument_name] = field.dotted_name
+    return qualified_names, options
+
+
+def _get_base_option_name(
+    dotted_name: DottedFieldName, aliases: Dict[DottedFieldName, OptionName], prefix: str = ""
+) -> OptionName:
+    parents = dotted_name.split(".")
+    for i in range(len(parents) + 1, 0, -1):
+        parent = DottedFieldName(".".join(parents[:i]))
+        alias = aliases.get(parent)
+        if not alias:
+            continue
+        suffix = snake_case_to_kebab_case("-".join(parents[i:]))
+        if suffix:
+            if "/" in alias:
+                raise ValueError(
+                    f"Invalid boolean alias `{alias}` for field `{parent}`: boolean aliases can only be used for "
+                    f"boolean fields, however `{parent}` has child field `{suffix}`."
+                )
+            return OptionName(alias + "-" + suffix)
+        return alias
+    if prefix:
+        return OptionName(snake_case_to_kebab_case("-".join((prefix, *parents))))
+    else:
+        return OptionName("--" + snake_case_to_kebab_case(dotted_name))
+
+
+def _convert_to_valid_prefix(name: str) -> str:
+    return ("--" + name.removesuffix("-").removeprefix("-").removeprefix("-")) if name else name
+
+
+def get_option_name(
+    dotted_name: DottedFieldName,
+    *,
+    aliases: Dict[DottedFieldName, OptionName],
+    is_boolean: bool = False,
+    prefix: str = "",
+) -> OptionName:
+    """Get the option name from a dotted field name.
+
+    >>> get_option_name("foo_bar", aliases={})
+    '--foo-bar'
+    >>> get_option_name("foo", aliases={}, is_boolean=True)
+    '--foo/--no-foo'
+    >>> get_option_name("foo.bar.baz", aliases={"foo.bar.baz": "--alias"})
+    '--alias'
+    >>> get_option_name("foo.bar.baz", aliases={"foo.bar": "--alias"})
+    '--alias-baz'
+    >>> get_option_name("bar", aliases={}, is_boolean=True, prefix="--foo")
+    '--foo-bar/--no-foo-bar'
+
+    Args:
+        dotted_name: dotted name of the field (i.e. the field name and all its parent names, joined by a dot)
+        aliases: mapping from dotted field names to option names, used to override default option names. Aliases must
+            use kebab case and start with two dashes.
+        is_boolean: whether the field is a boolean flag. Boolean flags have a specific behavior in Click: they have
+            two option names, separated with a slash, one for True and one for False (for example, `--shout/--no-shout`)
+        prefix: prefix to preprend to the option name. Ignored if an alias was found for `dotted_name` or one of its
+            parent. If provided, prefix must use kebab case and start with two dashes.
+
+    Return:
+        option name, in kebab case and with two leading dashes
+    """
+    base_name = _get_base_option_name(dotted_name, aliases=aliases, prefix=prefix)
+    if not is_boolean or "/" in base_name:
+        return base_name
+    else:
+        return OptionName(f"{base_name}/--no-{base_name.removeprefix('--')}")
+
+
+def _get_option_from_field(
+    argument_name: ArgumentName,
+    option_name: str,
+    field_info: FieldInfo,
+    documentation: str | None = None,
+    short_name: Optional[str] = None,
+    option_kwargs: Optional[_ParameterKwargs] = None,
+) -> click.Option:
+    """Convert a Pydantic field to a Click option.
+
+    Args:
+        argument_name: argument name (i.e. name of the variable that will receive the option). Must be a valid Python
+            identifier, distinct from all other argument names for the same command
+        option_name: name of the option (in kebab-case, starting with two dashes)
+        field_info: field to convert
+        documentation: help string for the option
+        short_name: short name of the option (one dash and one letter)
+        option_kwargs: extra options to pass to `click.option`
+
+    Returns:
+        `click.Option` object
+    """
+    param_decls = [argument_name, option_name]
+    if short_name is not None:
+        param_decls.append(short_name)
+    kwargs: _ParameterKwargs = {
+        "type": _get_type_from_field(field_info),
+        "default": _get_default_value_from_field(field_info),
+        "required": field_info.is_required(),
+        "help": documentation,
+    }
+    if option_kwargs is not None:
+        kwargs.update(option_kwargs)
+    return click.Option(param_decls=param_decls, **kwargs)
+
+
+def _get_default_value_from_field(field: FieldInfo) -> Union[Any, Callable[[], Any], None]:
+    """Return the default value of `field`.
+
+    Args:
+         field: Pydantic field
+
+    Returns:
+        either the default value or the default factory or None if field has no default
+    """
+    if field.default is not PydanticUndefined:
+        return field.default
+    elif field.default_factory is not None:
+        return field.default_factory
+    return None

--- a/pydanclick/model/field_conversion.py
+++ b/pydanclick/model/field_conversion.py
@@ -132,7 +132,7 @@ def _get_option_from_field(
     argument_name: ArgumentName,
     option_name: str,
     field_info: FieldInfo,
-    documentation: str | None = None,
+    documentation: Optional[str] = None,
     short_name: Optional[str] = None,
     option_kwargs: Optional[_ParameterKwargs] = None,
 ) -> click.Option:

--- a/pydanclick/model/field_conversion.py
+++ b/pydanclick/model/field_conversion.py
@@ -63,7 +63,7 @@ def convert_fields_to_options(
 
 def _get_base_option_name(
     dotted_name: DottedFieldName, aliases: Dict[DottedFieldName, OptionName], prefix: str = ""
-) -> OptionName:
+) -> str:
     parents = dotted_name.split(".")
     for i in range(len(parents) + 1, 0, -1):
         parent = DottedFieldName(".".join(parents[:i]))
@@ -77,12 +77,12 @@ def _get_base_option_name(
                     f"Invalid boolean alias `{alias}` for field `{parent}`: boolean aliases can only be used for "
                     f"boolean fields, however `{parent}` has child field `{suffix}`."
                 )
-            return OptionName(alias + "-" + suffix)
+            return alias + "-" + suffix
         return alias
     if prefix:
-        return OptionName(snake_case_to_kebab_case("-".join((prefix, *parents))))
+        return snake_case_to_kebab_case("-".join((prefix, *parents)))
     else:
-        return OptionName("--" + snake_case_to_kebab_case(dotted_name))
+        return "--" + snake_case_to_kebab_case(dotted_name)
 
 
 def _convert_to_valid_prefix(name: str) -> str:
@@ -125,7 +125,7 @@ def get_option_name(
     """
     base_name = _get_base_option_name(dotted_name, aliases=aliases, prefix=prefix)
     if not is_boolean or "/" in base_name:
-        return base_name
+        return OptionName(base_name)
     else:
         if base_name.startswith("--"):
             base_name = base_name[2:]

--- a/pydanclick/model/model_conversion.py
+++ b/pydanclick/model/model_conversion.py
@@ -1,0 +1,80 @@
+"""Convert a Pydantic model to Click options, and provide function to convert Click arguments back to Pydantic."""
+
+import functools
+from typing import Callable, Dict, List, Literal, Optional, Sequence, Set, Tuple, Type, TypeVar, cast
+
+import click
+from pydantic import BaseModel
+
+from pydanclick.model.field_collection import collect_fields
+from pydanclick.model.field_conversion import convert_fields_to_options
+from pydanclick.model.validation import model_validate_kwargs
+from pydanclick.types import DottedFieldName, OptionName, _ParameterKwargs
+
+T = TypeVar("T")
+M = TypeVar("M", bound=BaseModel)
+
+
+def convert_to_click(
+    model: Type[M],
+    *,
+    exclude: Sequence[str] = (),
+    rename: Optional[Dict[str, str]] = None,
+    shorten: Optional[Dict[str, str]] = None,
+    prefix: str | None = None,
+    parse_docstring: bool = True,
+    docstring_style: Literal["google", "numpy", "sphinx"] = "google",
+    extra_options: Optional[Dict[str, _ParameterKwargs]] = None,
+) -> Tuple[List[click.Option], Callable[..., M]]:
+    """Extract Click options from a Pydantic model.
+
+    Here's an example on how it can be used:
+    ```python
+    import click
+    from pydanclick.model import convert_to_click
+    from pydanclick.command import add_options
+
+    options, validate = convert_to_click(MyModel)
+
+    @click.command()
+    @add_options(options)
+    def func(**kwargs):
+        my_obj = validate(kwargs)
+        assert isinstance(my_obj, MyModel)  # True
+    ```
+    In real life however, you can simply use `pydanclick.from_pydantic()` to avoid the boilerplate.
+
+    Args:
+        model: Pydantic model
+        exclude: fields to exclude. Use dotted names for nested fields (i.e. parent names and field name, joined by
+            a dot). Excluded fields must have a default value: otherwise, model instantiation will fail.
+        rename: a mapping from dotted field names to option names, to override the default values
+        shorten: a mapping from dotted field names to short option names
+        prefix: prefix to add to option names. Can be useful to disambiguate field with the same names from different
+            models. Prefix won't be added to aliases or short option names.
+        parse_docstring: if True, parse model docstring to extract field documentation
+        docstring_style: docstring style of the model. Only used if `parse_docstring=True`
+        extra_options: extra options to pass to `click.Option` for specific fields, as a mapping from dotted field names
+            to option dictionary
+
+    Returns:
+        a pair `(options, validate)` where `options` is the list of Click options extracted from the model, and
+            `validate` is a function that can instantiate a model from the list of arguments parsed by Click
+    """
+    # We're doing a lot of casting here, to convert regular strings provided by the user into specific string types
+    # used internally to disambiguate the different names associated with a field (option, argument, dotted...)
+    fields = collect_fields(
+        obj=model,
+        excluded_fields=cast(Set[DottedFieldName], set(exclude)),
+        docstring_style=docstring_style,
+        parse_docstring=parse_docstring,
+    )
+    qualified_names, options = convert_fields_to_options(
+        fields,
+        prefix=prefix,
+        aliases=cast(Optional[Dict[DottedFieldName, OptionName]], rename),
+        shorten=cast(Optional[Dict[DottedFieldName, OptionName]], shorten),
+        extra_options=cast(Dict[DottedFieldName, _ParameterKwargs], extra_options),
+    )
+    validator = functools.partial(model_validate_kwargs, model=model, qualified_names=qualified_names)
+    return options, validator

--- a/pydanclick/model/model_conversion.py
+++ b/pydanclick/model/model_conversion.py
@@ -21,7 +21,7 @@ def convert_to_click(
     exclude: Sequence[str] = (),
     rename: Optional[Dict[str, str]] = None,
     shorten: Optional[Dict[str, str]] = None,
-    prefix: str | None = None,
+    prefix: Optional[str] = None,
     parse_docstring: bool = True,
     docstring_style: Literal["google", "numpy", "sphinx"] = "google",
     extra_options: Optional[Dict[str, _ParameterKwargs]] = None,

--- a/pydanclick/model/type_conversion.py
+++ b/pydanclick/model/type_conversion.py
@@ -1,0 +1,144 @@
+"""Convert Pydantic types to Click types."""
+
+import datetime
+import re
+from pathlib import Path
+from typing import Any, List, Literal, Type, TypedDict, Union, get_args, get_origin
+from uuid import UUID
+
+import click
+from annotated_types import Ge, Gt, Le, Lt, SupportsGe, SupportsGt, SupportsLe, SupportsLt
+from pydantic import TypeAdapter, ValidationError
+from pydantic.fields import FieldInfo
+
+NoneType = type(None)
+
+
+class _RangeDict(TypedDict, total=False):
+    """Represent arguments to `click.IntRange` or `click.FloatRange`."""
+
+    max: Union[SupportsLt, SupportsLe]
+    min: Union[SupportsGt, SupportsGe]
+    max_open: bool
+    min_open: bool
+
+
+def _get_range_from_metadata(metadata: List[Any]) -> _RangeDict:
+    """Convert Pydantic numerical constraints to keyword argumetns compatible with `IntRange` and `FloatRange`.
+
+    Args:
+        metadata: list of Pydantic constraints
+
+    Returns:
+        a dictionary
+    """
+    range_args: _RangeDict = {}
+    for constraint in metadata:
+        if isinstance(constraint, Le):
+            range_args["max"] = constraint.le
+            range_args["max_open"] = False
+        if isinstance(constraint, Lt):
+            range_args["max"] = constraint.lt
+            range_args["max_open"] = True
+        if isinstance(constraint, Ge):
+            range_args["min"] = constraint.ge
+            range_args["min_open"] = False
+        if isinstance(constraint, Gt):
+            range_args["min"] = constraint.gt
+            range_args["min_open"] = True
+    return range_args
+
+
+def _get_numerical_type(field: FieldInfo) -> click.ParamType:
+    """Convert a numerical field to a Click parameter type.
+
+    Converts Pydantic numerical constraints (e.g. `Field(gt=0)` or `Field(le=10)`) into a Click range type such as
+    `IntRange` or `FloatRange`. Unconstrained types result in `click.INT` or `click.FLOAT` types. Decimal types or any
+    non-integer numerical type will be treated as a float.
+
+    Args:
+        field: field to convert
+
+    Returns:
+        either `click.INT`, `click.FLOAT` or an instance of `click.IntRange` or `click.FloatRange`
+    """
+    range_args = _get_range_from_metadata(field.metadata)
+    if field.annotation is int:
+        if range_args:
+            return click.IntRange(**range_args)  # type: ignore[arg-type]
+        return click.INT
+    # Non-integer numerical types default to float
+    if range_args:
+        return click.FloatRange(**range_args)  # type: ignore[arg-type]
+    return click.FLOAT
+
+
+def _get_type_from_field(field: FieldInfo) -> click.ParamType:
+    """Get the Click type for a Pydantic field.
+
+    Pydantic and Click both define custom types for validating arguments. This function attempts to map Pydantic field
+    types to Click `ParamType` instances, on a best effort basis. Pydantic types may be stricted than their Click
+    counterparts: in that case, validation will happen when instantiating the Pydantic model, not when Click parses
+    the CLI arguments. When no equivalent is found, Click won't perform any validation and Pydantic will receive raw
+    strings.
+
+    Args:
+        field: field to convert
+
+    Returns:
+        a Click type
+    """
+    field_type = field.annotation
+    field_args = get_args(field_type)
+    field_origin = get_origin(field_type)
+    # TODO: handle annotated
+    # TODO: handle subclasses
+    if field_origin is Union and len(field_args) == 2 and NoneType in field_args and field.default is None:
+        # Optional types where None is only used as a default value can be safely treated as a
+        # non-optional type, since Click doesn't really distinguish between a strign with default value None from
+        # an actual str
+        field_type = next(field_arg for field_arg in field_args if field_arg is not None)
+    if field_type is str:
+        return click.STRING
+    elif field_type in (int, float):
+        return _get_numerical_type(field)
+    elif field_type is float:
+        return click.FLOAT
+    elif field_type is bool:
+        return click.BOOL
+    elif field_type is UUID:
+        return click.UUID
+    elif field_type is Path:
+        return click.Path(path_type=Path)
+    elif field_type in (datetime.datetime, datetime.date):
+        return click.DateTime()
+    elif field_origin is Literal:
+        # TODO: allow converting literal to feature switches
+        return click.Choice(field_args)
+    else:
+        return _create_custom_type(field)
+
+
+def _create_custom_type(field: FieldInfo) -> click.ParamType:
+    """Create a custom Click type from a Pydantic field."""
+    name = "".join(part.capitalize() for part in re.split(r"\W", str(field.annotation)) if part)
+    type_adapter = TypeAdapter(field.annotation)
+
+    def convert(self, value, param, ctx):  # type: ignore[no-untyped-def]
+        try:
+            if isinstance(value, str):
+                return type_adapter.validate_json(value)
+            else:
+                return type_adapter.validate_python(value)
+        except ValidationError as e:
+            self.fail(str(e), param, ctx)
+
+    custom_type: Type[click.ParamType] = type(
+        name,
+        (click.ParamType,),
+        {
+            "name": "JSON STRING",
+            "convert": convert,
+        },
+    )
+    return custom_type()

--- a/pydanclick/model/validation.py
+++ b/pydanclick/model/validation.py
@@ -1,0 +1,86 @@
+"""Validation consists in converting the arguments (passed to the Click command) to a Pydantic model.
+
+Validation involves the following steps:
+
+- collect arguments that corresponds to a Pydantic field
+- create a flat representation of the object (with nested field names separated by dots)
+- unflatten this representation
+- pass the nested representation to the `model_validate` method of the Pydantic model
+"""
+
+from typing import Any, Dict, Type
+
+from pydantic import BaseModel
+from typing_extensions import TypeVar
+
+from pydanclick.types import ArgumentName, DottedFieldName
+
+M = TypeVar("M", bound=BaseModel)
+V = TypeVar("V")
+K = TypeVar("K", bound=str)
+
+
+def model_validate_kwargs(
+    kwargs: Dict[ArgumentName, Any], model: Type[M], qualified_names: Dict[ArgumentName, DottedFieldName]
+) -> M:
+    """Instantiate `model` for keyword arguments.
+
+    >>> class Foo(BaseModel):
+    ...     a: int
+    >>> class Bar(BaseModel):
+    ...     b: Foo
+    ...     c: str
+    >>> model_validate_kwargs({"arg1": 1, "arg2": "c"}, Bar, {"arg1": "b.a", "arg2": "c"})
+    Bar(b=Foo(a=1), c='c')
+
+    Args:
+        kwargs: mapping from argument name to their values
+        model: Pydantic model to instantiate
+        qualified_names: a mapping from argument names to corresponding dotted field names
+
+    Returns:
+        an instance of `model` with the provided values
+    """
+    flat_model = _parse_options(qualified_names, kwargs)
+    raw_model = _unflatten_dict(flat_model)
+    return model.model_validate(raw_model)
+
+
+def _unflatten_dict(d: Dict[K, V], sep: str = ".") -> Dict[str, Any]:
+    """Create a nested dictionary from a flat dictionary.
+
+    >>> _unflatten_dict({"a.b.c": "abc", "a.b.d": "def", "a.e": "ghi", "f": 1})
+    {'a': {'b': {'c': 'abc', 'd': 'def'}, 'e': 'ghi'}, 'f': 1}
+
+    Args:
+        d: flat mapping with strings as keys
+        sep: separator used to separate different levels of nesting in a key
+    """
+    nested: Dict[str, Any] = {}
+    for k, v in d.items():
+        if not k:
+            raise ValueError("Empty keys are not supported")
+        parts = k.split(sep)
+        current_dict = nested
+        for part in parts[:-1]:
+            current_dict = current_dict.setdefault(part, {})
+        current_dict[parts[-1]] = v
+    return nested
+
+
+def _parse_options(
+    aliases: Dict[ArgumentName, DottedFieldName], kwargs: Dict[ArgumentName, V]
+) -> Dict[DottedFieldName, V]:
+    """Extract keys and values from `kwargs`.
+
+    Args:
+        aliases: mapping from argument name to field name
+        kwargs: mapping from argument name to their values. Note that `kwargs` will be modified in-place
+
+    Returns:
+        mapping from field name to their values
+    """
+    parsed = {}
+    for key in aliases.keys() & kwargs.keys():
+        parsed[aliases[key]] = kwargs.pop(key)
+    return parsed

--- a/pydanclick/types.py
+++ b/pydanclick/types.py
@@ -1,0 +1,32 @@
+from typing import Any, Optional, TypedDict, Union
+
+import click
+from typing_extensions import NewType
+
+
+class _ParameterKwargs(TypedDict, total=False):
+    """Represent valid parameters for `click.option()`."""
+
+    show_default: Union[bool, str, None]
+    prompt: Union[bool, str]
+    confirmation_prompt: Union[bool, str]
+    prompt_required: bool
+    hide_input: bool
+    is_flag: Optional[bool]
+    flag_value: Optional[Any]
+    multiple: bool
+    count: bool
+    allow_from_autoenv: bool
+    type: Optional[Union[click.ParamType, Any]]
+    help: Optional[str]
+    hidden: bool
+    show_choices: bool
+    show_envvar: bool
+    required: bool
+    default: Any
+
+
+ArgumentName = NewType("ArgumentName", str)
+OptionName = NewType("OptionName", str)
+FieldName = NewType("FieldName", str)
+DottedFieldName = NewType("DottedFieldName", str)

--- a/pydanclick/utils.py
+++ b/pydanclick/utils.py
@@ -1,0 +1,49 @@
+import re
+
+_CAMEL_CASE_PATTERN = re.compile(r"(?<!^)(?=[A-Z])")
+
+
+def camel_case_to_snake_case(name: str) -> str:
+    """Convert camel case name to snake case.
+
+    >>> camel_case_to_snake_case('FooBar')
+    'foo_bar'
+
+    """
+    return _CAMEL_CASE_PATTERN.sub("_", name).lower()
+
+
+def snake_case_to_kebab_case(name: str) -> str:
+    """Convert snake case or dotted name to kebab case.
+
+    >>> snake_case_to_kebab_case('a_b')
+    'a-b'
+
+    >>> snake_case_to_kebab_case('a.b')
+    'a-b'
+
+    """
+    return name.lower().replace("_", "-").replace(".", "-")
+
+
+def kebab_case_to_snake_case(name: str) -> str:
+    """Convert kebab case to snake case.
+
+    >>> kebab_case_to_snake_case('a-b')
+    'a_b'
+
+    """
+    return name.replace("-", "_")
+
+
+def strip_option_name(name: str) -> str:
+    """Strip leading and trailing dashes from an option name.
+
+    >>> strip_option_name('-a')
+    'a'
+
+    >>> strip_option_name('--foo-bar-')
+    'foo-bar'
+
+    """
+    return re.sub("-+$", "", re.sub("^-+", "", name))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,8 @@ ignore = [
     "E501",
     # DoNotAssignLambda
     "E731",
+    # Long messages in exception
+    "TRY003",
 ]
 
 [tool.ruff.format]

--- a/tests/base_models.py
+++ b/tests/base_models.py
@@ -1,0 +1,23 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class Foo(BaseModel):
+    a: int = 1
+    b: bool = True
+
+
+class Baz(BaseModel):
+    c: Literal["a", "b"] = "a"
+
+
+class Bar(BaseModel):
+    a: float = 0.1
+    b: str = "b"
+    baz: Baz = Field(default_factory=Baz)
+
+
+class Obj(BaseModel):
+    foo: Foo = Field(default_factory=Foo)
+    bar: Bar = Field(default_factory=Bar)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+from contextlib import nullcontext as does_not_raise
+from typing import Iterable
+
+import click
+from _pytest.python_api import RaisesContext
+
+
+def assert_option_equals(actual: click.Option, expected: click.Option) -> None:
+    assert actual.__dict__ == expected.__dict__
+
+
+def assert_options_equals(actuals: Iterable[click.Option], expecteds: Iterable[click.Option]) -> None:
+    actuals = sorted(actuals, key=lambda o: o.name)
+    expecteds = sorted(expecteds, key=lambda o: o.name)
+    assert len(actuals) == len(expecteds), f"Different number of options: {len(actuals)} != {len(expecteds)}"
+    for i, (actual, expected) in enumerate(zip(actuals, expecteds)):
+        assert (
+            actual.__dict__ == expected.__dict__
+        ), f"Different option at index {i}: {actual.__dict__} != {expected.__dict__}"
+
+
+def maybe_raises(outcome):
+    return outcome if isinstance(outcome, RaisesContext) else does_not_raise()
+
+
+def error_or_value(outcome):
+    if isinstance(outcome, RaisesContext):
+        context = outcome
+        assert_is_expected = lambda x: True
+        return context, assert_is_expected
+    else:
+
+        def assert_is_expected(__x):
+            assert __x == outcome
+
+        return does_not_raise(), assert_is_expected

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,0 +1,16 @@
+import click
+from click.testing import CliRunner
+
+from pydanclick.command import add_options
+
+
+def test_add_options():
+    options = [click.Option(["--foo"]), click.Option(["--bar"])]
+
+    def cli(foo, bar):
+        click.echo(f"foo={foo}, bar={bar}")
+
+    cli = click.command()(add_options(cli, options))
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--foo", "abc", "--bar", "123"])
+    assert result.output.strip() == "foo=abc, bar=123"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-from examples import complex, simple
+from examples import complex, complex_types, simple
 
 
 @pytest.mark.parametrize(
@@ -69,3 +69,20 @@ def test_complex_example_help():
     result = runner.invoke(complex.cli, ["--help"])
     # Ensure field description is added to the CLI documentation
     assert "Attach a description directly in the field" in result.output
+
+
+@pytest.mark.parametrize(
+    "args, expected_results",
+    [
+        ([], {}),
+        (["--mounts", "[]"], {}),
+        (["--mounts", '[["bind", ".", "."]]'], {"mounts": [["bind", ".", "."]]}),
+        (["--ports", '{"80": 80, "8888": 8888}'], {"ports": {"80": 80, "8888": 8888}}),
+    ],
+)
+def test_complex_types_example(args, expected_results):
+    """Ensure the 'complex_types' examples works."""
+    runner = CliRunner()
+    result = runner.invoke(complex_types.cli, ["--image", "foo", *args])
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {"image": "foo", "mounts": [], "ports": {}} | expected_results

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -85,4 +85,4 @@ def test_complex_types_example(args, expected_results):
     runner = CliRunner()
     result = runner.invoke(complex_types.cli, ["--image", "foo", *args])
     assert result.exit_code == 0
-    assert json.loads(result.output) == {"image": "foo", "mounts": [], "ports": {}} | expected_results
+    assert json.loads(result.output) == {"image": "foo", "mounts": [], "ports": {}, **expected_results}

--- a/tests/test_field_collection.py
+++ b/tests/test_field_collection.py
@@ -1,0 +1,19 @@
+from pydanclick.model.field_collection import _Field, collect_fields
+from tests.base_models import Bar, Baz, Foo, Obj
+
+
+def test_collect_fields():
+    fields = collect_fields(Obj)
+    assert fields == [
+        _Field(name="a", dotted_name="foo.a", field_info=Foo.model_fields["a"], parents=("foo", "a")),
+        _Field(name="b", dotted_name="foo.b", field_info=Foo.model_fields["b"], parents=("foo", "b")),
+        _Field(name="a", dotted_name="bar.a", field_info=Bar.model_fields["a"], parents=("bar", "a")),
+        _Field(name="b", dotted_name="bar.b", field_info=Bar.model_fields["b"], parents=("bar", "b")),
+        _Field(name="c", dotted_name="bar.baz.c", field_info=Baz.model_fields["c"], parents=("bar", "baz", "c")),
+    ]
+
+
+def test_collect_fields_with_exclude():
+    fields = collect_fields(Obj, excluded_fields=["foo", "bar.b"])
+    assert {field.dotted_name for field in fields} == {"bar.a", "bar.baz.c"}
+    # TODO: test docstring parsing

--- a/tests/test_field_conversion.py
+++ b/tests/test_field_conversion.py
@@ -1,0 +1,64 @@
+import click
+import pytest
+from pydantic.fields import FieldInfo
+
+from pydanclick.model.field_collection import _Field
+from pydanclick.model.field_conversion import convert_fields_to_options, get_option_name
+from tests.conftest import assert_options_equals
+
+
+def test_convert_fields_to_options():
+    str_field = FieldInfo(annotation=str, default="")
+    bool_field = FieldInfo(annotation=bool, default=True)
+    fields = [
+        _Field(name="a", dotted_name="foo.a", field_info=str_field, parents=("foo", "a")),
+        _Field(name="b", dotted_name="foo.b", field_info=str_field, parents=("foo", "b")),
+        _Field(name="a", dotted_name="bar.a", field_info=str_field, parents=("bar", "a")),
+        _Field(name="b", dotted_name="bar.b", field_info=bool_field, parents=("bar", "b")),
+        _Field(name="c", dotted_name="bar.baz.c", field_info=str_field, parents=("bar", "baz", "c")),
+    ]
+    _, options = convert_fields_to_options(
+        fields,
+        aliases={"foo.b": "foob", "bar": "rab"},
+        shorten={"bar.baz.c": "-b"},
+        extra_options={"bar.b": {"help": "help!"}},
+    )
+    assert_options_equals(
+        options,
+        [
+            click.Option(["foo_a", "--foo-a"], type=str, default=""),
+            click.Option(["foo_b", "--foob"], type=str, default=""),
+            click.Option(["bar_a", "--rab-a"], type=str, default=""),
+            click.Option(["bar_b", "--rab-b/--no-rab-b"], type=bool, default=True, help="help!"),
+            click.Option(["bar_baz_c", "--rab-baz-c", "-b"], type=str, default=""),
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "name, aliases, prefix, is_boolean, expected_result",
+    [
+        ("foo", {}, "", False, "--foo"),
+        ("foo", {}, "", True, "--foo/--no-foo"),
+        ("foo", {}, "--pref", False, "--pref-foo"),
+        ("foo", {}, "--pref", True, "--pref-foo/--no-pref-foo"),
+        ("foo_bar", {}, "", False, "--foo-bar"),
+        ("foo_bar", {}, "", True, "--foo-bar/--no-foo-bar"),
+        ("foo_bar", {}, "--pref", True, "--pref-foo-bar/--no-pref-foo-bar"),
+        ("Foo", {}, "", False, "--foo"),
+        ("foo.bar", {"foo": "--oof"}, "", False, "--oof-bar"),
+        ("foo.bar", {"foo": "--oof"}, "", True, "--oof-bar/--no-oof-bar"),
+        ("foo.bar", {"foo.bar": "--baz"}, "", False, "--baz"),
+        ("foo.bar", {"foo.bar": "--on/--off"}, "", False, "--on/--off"),
+        ("foo.bar", {"foo": "--oof", "foo.bar": "--baz"}, "", False, "--baz"),
+        ("foo.bar", {"foo": "--oof", "foo.bar": "--baz"}, "--pref", False, "--baz"),
+        ("foo.baz", {"foo": "--oof", "foo.bar": "--baz"}, "", False, "--oof-baz"),
+        ("foo.baz", {"foo": "--oof", "foo.bar": "--baz"}, "--pref", False, "--oof-baz"),
+        ("bar", {"foo": "--oof", "foo.bar": "--baz"}, "--pref", False, "--pref-bar"),
+    ],
+)
+def test_get_option_name(name, aliases, prefix, is_boolean, expected_result):
+    assert get_option_name(name, aliases=aliases, prefix=prefix, is_boolean=is_boolean) == expected_result
+
+
+# TODO: ensure prefix is correctly preprended to the argument name

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,16 +1,11 @@
-from contextlib import nullcontext as does_not_raise
-from typing import List, Literal, Union
+from typing import Dict, List
 
 import click
-import pytest
-from _pytest.python_api import RaisesContext
-from click import BadParameter
 from click.testing import CliRunner
-from pydantic import BaseModel, Field
-from typing_extensions import Annotated
+from pydantic import BaseModel
 
 from pydanclick import from_pydantic
-from pydanclick.main import _get_type_from_field
+from tests.base_models import Bar, Baz, Foo, Obj
 
 
 class Config(BaseModel):
@@ -31,81 +26,28 @@ def test_cli():
     assert Config.model_validate_json(result.output) == Config()
 
 
-def test_get_type_from_field_with_unconstrained_int():
+def test_nested():
+    @click.command()
+    @from_pydantic("obj", Obj)
+    def cli(obj: Obj):
+        click.echo(obj.model_dump_json(indent=2))
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--no-foo-b", "--bar-baz-c", "b", "--bar-a", "0.5"])
+    print(result.output)
+    assert Obj.model_validate_json(result.output) == Obj(foo=Foo(b=False), bar=Bar(a=0.5, baz=Baz(c="b")))
+
+
+def test_list_field():
     class Foo(BaseModel):
-        a: int
+        a: List[int]
+        b: Dict[str, int]
 
-    click_type = _get_type_from_field(Foo.model_fields["a"])
-    assert click_type == click.INT
+    @click.command()
+    @from_pydantic("foo", Foo)
+    def cli(foo: Foo):
+        assert foo.a == [1, 2, 3]
+        assert foo.b == {"a": 1, "b": 2, "c": 3}
 
-
-def test_get_type_from_field_with_constrained_int():
-    class Foo(BaseModel):
-        a: Annotated[int, Field(ge=0)]
-
-    click_type = _get_type_from_field(Foo.model_fields["a"])
-    assert isinstance(click_type, click.IntRange)
-    assert click_type.min == 0
-    assert click_type.min_open is False
-
-
-def maybe_raises(outcome):
-    return outcome if isinstance(outcome, RaisesContext) else does_not_raise()
-
-
-def error_or_value(outcome):
-    if isinstance(outcome, RaisesContext):
-        context = outcome
-        assert_is_expected = lambda x: True
-        return context, assert_is_expected
-    else:
-
-        def assert_is_expected(__x):
-            assert __x == outcome
-
-        return does_not_raise(), assert_is_expected
-
-
-@pytest.mark.parametrize(
-    "annotation, raw_value, expected_outcome",
-    [
-        (int, 1, 1),
-        (int, 1.2, 1),
-        (Annotated[int, Field(ge=0)], -2, pytest.raises(BadParameter, match="not in the range x>=0")),
-        (Annotated[int, Field(ge=0)], 0, 0),
-        (Annotated[int, Field(ge=0)], 10, 10),
-        (Annotated[int, Field(ge=0, le=10)], 10, 10),
-        (Annotated[int, Field(gt=0, lt=10)], 0, pytest.raises(BadParameter)),
-        (Annotated[int, Field(gt=0, lt=10)], 10, pytest.raises(BadParameter)),
-        (Annotated[int, Field(gt=0, lt=10)], 5, 5),
-        (Annotated[float, Field(ge=0)], -0.5, pytest.raises(BadParameter)),
-        (Annotated[float, Field(ge=0)], 0, 0),
-        (Annotated[float, Field(ge=0)], 0.5, 0.5),
-        (Annotated[float, Field(ge=0, le=1)], 1, 1),
-        (Annotated[float, Field(gt=0, lt=1)], 0, pytest.raises(BadParameter)),
-        (Annotated[float, Field(gt=0, lt=1)], 1, pytest.raises(BadParameter)),
-        (Annotated[float, Field(gt=0, lt=1)], 0.99, 0.99),
-        (Literal["a", "b", "c"], "a", "a"),
-        (Literal["a", "b", "c"], "c", "c"),
-        (Literal["a", "b", "c"], "d", pytest.raises(BadParameter)),
-        (bool, False, False),
-        (bool, True, True),
-        (bool, "yes", True),
-        (bool, "1", True),
-        (bool, "n", False),
-        (bool, "123", pytest.raises(BadParameter)),
-        (Annotated[bool, "foo_bar"], "yes", True),
-        (Union[float, str], "3.14", "3.14"),
-        (List[str], None, None),
-        (List[str], "[1, 2, 3, 4]", "[1, 2, 3, 4]"),
-    ],
-)
-def test_get_type_from_field(annotation, raw_value, expected_outcome):
-    class Foo(BaseModel):
-        bar: annotation
-
-    click_type = _get_type_from_field(Foo.model_fields["bar"])
-    context, check_expected = error_or_value(expected_outcome)
-    with context:
-        converted_value = click_type.convert(raw_value, None, None)
-        check_expected(converted_value)
+    result = CliRunner().invoke(cli, ["--a", "[1, 2, 3]", "--b", '{"a": 1, "b": 2, "c": 3}'])
+    assert result.exit_code == 0

--- a/tests/test_type_conversion.py
+++ b/tests/test_type_conversion.py
@@ -1,0 +1,73 @@
+from typing import List, Literal, Union
+
+import click
+import pytest
+from click import BadParameter
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
+
+from pydanclick.model.type_conversion import _get_type_from_field
+from tests.conftest import error_or_value
+
+
+def test_get_type_from_field_with_unconstrained_int():
+    class Foo(BaseModel):
+        a: int
+
+    click_type = _get_type_from_field(Foo.model_fields["a"])
+    assert click_type == click.INT
+
+
+def test_get_type_from_field_with_constrained_int():
+    class Foo(BaseModel):
+        a: Annotated[int, Field(ge=0)]
+
+    click_type = _get_type_from_field(Foo.model_fields["a"])
+    assert isinstance(click_type, click.IntRange)
+    assert click_type.min == 0
+    assert click_type.min_open is False
+
+
+@pytest.mark.parametrize(
+    "annotation, raw_value, expected_outcome",
+    [
+        (int, 1, 1),
+        (int, 1.2, 1),
+        (Annotated[int, Field(ge=0)], -2, pytest.raises(BadParameter, match="not in the range x>=0")),
+        (Annotated[int, Field(ge=0)], 0, 0),
+        (Annotated[int, Field(ge=0)], 10, 10),
+        (Annotated[int, Field(ge=0, le=10)], 10, 10),
+        (Annotated[int, Field(gt=0, lt=10)], 0, pytest.raises(BadParameter)),
+        (Annotated[int, Field(gt=0, lt=10)], 10, pytest.raises(BadParameter)),
+        (Annotated[int, Field(gt=0, lt=10)], 5, 5),
+        (Annotated[float, Field(ge=0)], -0.5, pytest.raises(BadParameter)),
+        (Annotated[float, Field(ge=0)], 0, 0),
+        (Annotated[float, Field(ge=0)], 0.5, 0.5),
+        (Annotated[float, Field(ge=0, le=1)], 1, 1),
+        (Annotated[float, Field(gt=0, lt=1)], 0, pytest.raises(BadParameter)),
+        (Annotated[float, Field(gt=0, lt=1)], 1, pytest.raises(BadParameter)),
+        (Annotated[float, Field(gt=0, lt=1)], 0.99, 0.99),
+        (Literal["a", "b", "c"], "a", "a"),
+        (Literal["a", "b", "c"], "c", "c"),
+        (Literal["a", "b", "c"], "d", pytest.raises(BadParameter)),
+        (bool, False, False),
+        (bool, True, True),
+        (bool, "yes", True),
+        (bool, "1", True),
+        (bool, "n", False),
+        (bool, "123", pytest.raises(BadParameter)),
+        (Annotated[bool, "foo_bar"], "yes", True),
+        (Union[float, str], "3.14", 3.14),
+        (List[str], "[]", []),
+        (List[str], """["1", "2", "3", "4"]""", ["1", "2", "3", "4"]),
+    ],
+)
+def test_get_type_from_field(annotation, raw_value, expected_outcome):
+    class Foo(BaseModel):
+        bar: annotation
+
+    click_type = _get_type_from_field(Foo.model_fields["bar"])
+    context, check_expected = error_or_value(expected_outcome)
+    with context:
+        converted_value = click_type.convert(raw_value, None, None)
+        check_expected(converted_value)


### PR DESCRIPTION
## Nested models

Nested models are supported :tada: 

Consider the following model:

```python

class Foo(BaseModel):
    a: int = 1
    b: bool = True


class Baz(BaseModel):
    c: Literal["a", "b"] = "a"


class Bar(BaseModel):
    a: float = 0.1
    b: str = "b"
    baz: Baz = Field(default_factory=Baz)


class Obj(BaseModel):
    foo: Foo = Field(default_factory=Foo)
    bar: Bar = Field(default_factory=Bar)
```

By default, it will translate into these options:

```
  --foo-a INTEGER
  --foo-b / --no-foo-b 
  --bar-a FLOAT
  --bar-b TEXT
  --bar-baz-c [a|b]
```

- Internally, all fields are now uniquely identified by their "dotted name", e.g. `bar.baz.c`
- If a field is aliased, all its sub-fields will use its alias: in the example above, passing `rename={"bar.baz": "alias"}` would transform `--bar-baz-c` into `--alias-c`
- All existing options (renaming, shortening, excluding, `extra_options`) can be applied to nested fields, using their dotted name

## Container types

Container types such as lists or dicts are supported :tada:

They can be passed to the command as JSON strings, e.g.

```shell
--option '{"a": [1, 2, 3], "b": [true, false, null]}'
```

In fact, any type that isn't recognized by `_get_type_from_field()` will be converted to a [custom Click type](https://click.palletsprojects.com/en/8.1.x/parameters/#implementing-custom-types) and validated through `TypeAdapter(field.annotation).validate_json()`. (Note that some constraint and custom validator may get lost in the process, so it's not 100% safe).

## Other changes

- Code reorg:
   - a single entrypoint `convert_to_click()` returning the list of options and the function able to parse Click arguments
   - a cleaner process: collect (possibly nested) fields from the model, convert them to options; after validation, create a flat representation of the model with dotted names, then unflatten it and validate it 
- Prefix is now appended to _argument names_ (=name of the parameter that will receive the parsed argument, before model instantiation), mitigating the risk of name conflicts
- Awfully large commit, sorry :shrug: 
