### PR TITLE
Provide default variable name for model

### DIFF
--- a/examples/complex.py
+++ b/examples/complex.py
@@ -47,9 +47,8 @@ class Config(BaseModel):
 
 @click.command()
 @click.option("--verbose/--no-verbose", default=False, help="Verbose output")
-@from_pydantic("training_config", TrainingConfig, extra_options={"batch_size": {"default": 12}})
+@from_pydantic(TrainingConfig, extra_options={"batch_size": {"default": 12}})
 @from_pydantic(
-    "optimizer_config",
     OptimizerConfig,
     prefix="opt",
     rename={"optimizer": "--opt"},
@@ -57,7 +56,6 @@ class Config(BaseModel):
     exclude=["decay_rate"],
 )
 @from_pydantic(
-    "loss_config",
     LossConfig,
     prefix="loss",
     rename={"func": "--loss"},

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -20,11 +20,11 @@ class TrainingConfig(BaseModel):
 
 
 @click.command()
-@from_pydantic("config", TrainingConfig)
-def cli(config: TrainingConfig):
+@from_pydantic(TrainingConfig)
+def cli(training_config: TrainingConfig):
     """A simple example with a few parameters and default behavior."""
     # Here, we receive an already validated Pydantic object.
-    click.echo(config.model_dump_json(indent=2))
+    click.echo(training_config.model_dump_json(indent=2))
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 from typing import Dict, List
 
 import click
+import pytest
 from click.testing import CliRunner
 from pydantic import BaseModel
 
@@ -51,3 +52,11 @@ def test_list_field():
 
     result = CliRunner().invoke(cli, ["--a", "[1, 2, 3]", "--b", '{"a": 1, "b": 2, "c": 3}'])
     assert result.exit_code == 0
+
+
+def test_from_pydantic_with_invalid_call():
+    with pytest.raises(ValueError, match="`model` must be provided"):
+
+        @from_pydantic("foo")
+        def cli(foo):
+            pass


### PR DESCRIPTION
Prior to this change, you had to provide a name for the injected Pydantic object:

```python
@click.command()
@from_pydantic("training_config", TrainingConfig)
def cli(training_config: TrainingConfig):
  pass
```

Now, this can be omitted. Pydanclick will use the snake case version of the model name (see `pydanclick.utils.camel_case_to_snake_case()`):

```python
@click.command()
@from_pydantic(TrainingConfig)
def cli(training_config: TrainingConfig):
  pass
```

Previous behavior still works, if you need custom variable name.

Closes #7 
