### PR TITLE
Read conversion options from `__pydanclick__` attribute

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,5 +1,8 @@
+<!-- prettier-ignore -->
 ::: pydanclick
-options:
-show_root_heading: false
-show_root_members_full_path: true
-show_root_full_path: true
+    options:
+        show_root_heading: false
+        show_root_members_full_path: true
+        show_root_full_path: true
+        members: [from_pydantic, PydanclickConfig]
+        group_by_category: false

--- a/docs/examples/reuse_models.md
+++ b/docs/examples/reuse_models.md
@@ -1,0 +1,38 @@
+# Re-use models across commands
+
+Here, we're using the `LoggingConfig` class in two different subcommands.
+To avoid duplicating parameters, we attach a Pydanclick configuration object directly to the class:
+
+```python hl_lines="22"
+--8<--
+reuse_models.py
+--8<--
+```
+
+```shell
+~ python examples/reuse_models.py foo --help                                                                                                       <aws:tooling>
+Usage: reuse_models.py foo [OPTIONS]
+
+Options:
+  -l, --log-level INTEGER   logging level
+  --log-filename TEXT       name of log file
+  --log-record-format TEXT  logging format
+  --help                    Show this message and exit.
+```
+
+```shell
+~ python examples/reuse_models.py bar --help                                                                                                       <aws:tooling>
+Usage: reuse_models.py bar [OPTIONS]
+
+Options:
+  -l, --logging-level INTEGER
+  --logging-filename TEXT
+  --logging-record-format TEXT
+  --help                        Show this message and exit.
+```
+
+Notes:
+
+- using `PydanclickConfig` is not required: a simple dict would work as well
+- options defined in `__pydanclick__` can be overridden for a specific command
+- all options to `from_pydantic` are supported

--- a/examples/reuse_models.py
+++ b/examples/reuse_models.py
@@ -1,0 +1,43 @@
+import logging
+
+import click
+from pydantic import BaseModel
+
+from pydanclick import PydanclickConfig, from_pydantic
+
+
+class LoggingConfig(BaseModel):
+    """Logging configuration.
+
+    Attributes:
+        level: logging level
+        filename: name of log file
+        record_format: logging format
+    """
+
+    level: int = logging.INFO
+    filename: str = "app.log"
+    record_format: str = "%(message)s"
+
+    __pydanclick__ = PydanclickConfig(prefix="log", shorten={"level": "-l"})
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@from_pydantic(LoggingConfig)
+def foo(logging_config: LoggingConfig):
+    click.echo(logging_config.model_dump_json(indent=2))
+
+
+@cli.command()
+@from_pydantic(LoggingConfig, prefix="logging", parse_docstring=False)
+def bar(logging_config: LoggingConfig):
+    click.echo(logging_config.model_dump_json(indent=2))
+
+
+if __name__ == "__main__":
+    cli()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
       - Multiple Models: examples/complex.md
       - Nested Models: examples/nested.md
       - Complex Types: examples/complex_types.md
+      - Reuse Models: examples/reuse_models.md
   - Contributing: contributing.md
 plugins:
   - search

--- a/pydanclick/__init__.py
+++ b/pydanclick/__init__.py
@@ -1,3 +1,4 @@
 from pydanclick.main import from_pydantic
+from pydanclick.model import PydanclickConfig
 
-__all__ = ("from_pydantic",)
+__all__ = ("from_pydantic", "PydanclickConfig")

--- a/pydanclick/main.py
+++ b/pydanclick/main.py
@@ -19,7 +19,7 @@ def from_pydantic(
     rename: Optional[Dict[str, str]] = None,
     shorten: Optional[Dict[str, str]] = None,
     prefix: Optional[str] = None,
-    parse_docstring: bool = True,
+    parse_docstring: Optional[bool] = None,
     docstring_style: Literal["google", "numpy", "sphinx"] = "google",
     extra_options: Optional[Dict[str, _ParameterKwargs]] = None,
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:

--- a/pydanclick/model/__init__.py
+++ b/pydanclick/model/__init__.py
@@ -1,5 +1,6 @@
 """Analyze a Pydantic model and turn it into Click options."""
 
+from pydanclick.model.config import PydanclickConfig
 from pydanclick.model.model_conversion import convert_to_click
 
-__all__ = ("convert_to_click",)
+__all__ = ("convert_to_click", "PydanclickConfig")

--- a/pydanclick/model/config.py
+++ b/pydanclick/model/config.py
@@ -1,0 +1,104 @@
+from typing import Any, Dict, Literal, Optional, Sequence, Set, Type
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pydanclick.types import DottedFieldName, OptionName, _ParameterKwargs
+
+unset = object()
+_PYDANCLICK_OPTION_ATTRIBUTE = "__pydanclick__"
+
+
+class PydanclickConfig(BaseModel):
+    """Configure how to turn a model into Click options.
+
+    When converting a Pydantic model to Click options, Pydanclick will look for an `__pydanclick__` attribute of the
+    model, and read custom conversion parameters from it. This attribute can be a `PydanclickConfig` object, or a
+    dictionary with the same keys.
+
+    ```python
+    class Foo(BaseModel):
+        a: int
+        b: str
+        c: float
+
+        __pydanclick__ = PydanclickConfig(prefix="foo")
+    ```
+
+    Attributes:
+        exclude: fields to exclude
+        rename: fields to rename
+        shorten: fields to shorten
+        prefix: prefix to prepend to the option names
+        parse_docstring: if True, create option help strings from docstring
+        docstring_style: docstring style
+        extra_options: provide extra options to specific fields
+    """
+
+    exclude: Sequence[str] = ()
+    rename: Optional[Dict[str, str]] = None
+    shorten: Optional[Dict[str, str]] = None
+    prefix: Optional[str] = None
+    parse_docstring: bool = True
+    docstring_style: Literal["google", "numpy", "sphinx"] = "google"
+    extra_options: Optional[Dict[str, _ParameterKwargs]] = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class _Config(BaseModel):
+    exclude: Set[DottedFieldName] = Field(default_factory=set)
+    aliases: Optional[Dict[DottedFieldName, OptionName]] = Field(None, alias="rename")
+    shorten: Optional[Dict[DottedFieldName, OptionName]] = None
+    prefix: Optional[str] = None
+    parse_docstring: bool = True
+    docstring_style: Literal["google", "numpy", "sphinx"] = "google"
+    extra_options: Optional[Dict[DottedFieldName, _ParameterKwargs]] = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+def get_config(
+    model: Type[BaseModel],
+    *,
+    exclude: Sequence[str] = (),
+    rename: Optional[Dict[str, str]] = None,
+    shorten: Optional[Dict[str, str]] = None,
+    prefix: Optional[str] = None,
+    parse_docstring: Optional[bool] = None,
+    docstring_style: Literal["google", "numpy", "sphinx"] = "google",
+    extra_options: Optional[Dict[str, _ParameterKwargs]] = None,
+) -> _Config:
+    """Get conversion config for a given model.
+
+    Config parameters are read from three sources (by decreasing priority):
+
+    - non-default arguments provided to `get_config`
+    - `__pydanclick__` attribute of `model`, if any
+    - default values
+
+    Args:
+        model: Pydantic class to convert
+        *args: see `from_pydantic` help
+
+    Returns:
+        a validated conversion config
+    """
+    default_options = getattr(model, _PYDANCLICK_OPTION_ATTRIBUTE, {})
+    if isinstance(default_options, PydanclickConfig):
+        default_options = default_options.model_dump(exclude_unset=True)
+    overriding_options: Dict[str, Any] = {
+        key: value
+        for key, value in [
+            ("rename", rename),
+            ("shorten", shorten),
+            ("prefix", prefix),
+            ("parse_docstring", parse_docstring),
+            ("extra_options", extra_options),
+        ]
+        if value is not None
+    }
+    if exclude:
+        overriding_options["exclude"] = exclude
+    if "docstring_style" not in default_options:
+        overriding_options["docstring_style"] = docstring_style
+    return _Config.model_validate({**default_options, **overriding_options})

--- a/pydanclick/types.py
+++ b/pydanclick/types.py
@@ -1,7 +1,7 @@
-from typing import Any, Optional, TypedDict, Union
+from typing import Any, Optional, Union
 
 import click
-from typing_extensions import NewType
+from typing_extensions import NewType, TypedDict
 
 
 class _ParameterKwargs(TypedDict, total=False):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,80 @@
+from pydantic import BaseModel
+
+from pydanclick.model.config import PydanclickConfig, _Config, get_config
+
+
+def test_get_config_without_parameters_and_config():
+    class Foo(BaseModel):
+        a: int
+        b: str = "123"
+
+    assert get_config(Foo) == _Config(
+        exclude=set(),
+        rename=None,
+        shorten=None,
+        parse_docstring=True,
+        docstring_style="google",
+        prefix=None,
+        extra_options=None,
+    )
+
+
+def test_get_config_with_config_and_no_parameters():
+    class Foo(BaseModel):
+        a: int
+        b: str = "123"
+
+        __pydanclick__ = {
+            "exclude": ["a"],
+            "parse_docstring": False,
+        }
+
+    assert get_config(Foo) == _Config(
+        exclude={"a"},
+        rename=None,
+        shorten=None,
+        parse_docstring=False,
+        docstring_style="google",
+        prefix=None,
+        extra_options=None,
+    )
+
+
+def test_get_config_with_config_and_parameters():
+    class Foo(BaseModel):
+        a: int
+        b: str = "123"
+
+        __pydanclick__ = {
+            "exclude": ["a"],
+            "parse_docstring": False,
+        }
+
+    assert get_config(Foo, exclude=["b"], extra_options={"a": {"prompt": True}}) == _Config(
+        exclude={"b"},
+        rename=None,
+        shorten=None,
+        parse_docstring=False,
+        docstring_style="google",
+        prefix=None,
+        extra_options={"a": {"prompt": True}},
+    )
+    assert get_config(Foo, parse_docstring=True).parse_docstring is True
+
+
+def test_get_config_with_validated_config():
+    class Foo(BaseModel):
+        a: int
+        b: str = "123"
+
+        __pydanclick__ = PydanclickConfig(exclude=["a"], parse_docstring=False)
+
+    assert get_config(Foo, exclude=["b"], extra_options={"a": {"prompt": True}}) == _Config(
+        exclude={"b"},
+        rename=None,
+        shorten=None,
+        parse_docstring=False,
+        docstring_style="google",
+        prefix=None,
+        extra_options={"a": {"prompt": True}},
+    )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-from examples import complex, complex_types, simple
+from examples import complex, complex_types, reuse_models, simple
 
 
 @pytest.mark.parametrize(
@@ -86,3 +86,27 @@ def test_complex_types_example(args, expected_results):
     result = runner.invoke(complex_types.cli, ["--image", "foo", *args])
     assert result.exit_code == 0
     assert json.loads(result.output) == {"image": "foo", "mounts": [], "ports": {}, **expected_results}
+
+
+@pytest.mark.parametrize(
+    "args, expected_results",
+    [
+        (["foo"], {}),
+        (["bar"], {}),
+        (["foo", "-l", "30"], {"level": 30}),
+        (["foo", "--log-level", "30"], {"level": 30}),
+        (["bar", "-l", "30"], {"level": 30}),
+        (["bar", "--logging-level", "30"], {"level": 30}),
+    ],
+)
+def test_reuse_models_example(args, expected_results):
+    """Ensure the 'reuse_models' examples works."""
+    runner = CliRunner()
+    result = runner.invoke(reuse_models.cli, args)
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "filename": "app.log",
+        "level": 20,
+        "record_format": "%(message)s",
+        **expected_results,
+    }


### PR DESCRIPTION
Closes #8 

Specify conversion options directly in the model class (instead of passing them to `@from_pydantic`):
```python
class MyModel(BaseModel):
    __pydanclick__ = {
      "prefix": "pref",
      "exclude": ["a", "b"]
    }
```

In addition, a Pydantic model is exposed to ensure the content is valid:

```python
from pydanclick import PydanclickConfig

class MyModel(BaseModel):
  __pydanclick__ = PydanclickConfig(prefix="pref", exclude=["a", "b"])
```
