### PR TITLE
refactor: catch exceptions raised by issubclass

### DIFF
--- a/pydanclick/model/field_collection.py
+++ b/pydanclick/model/field_collection.py
@@ -84,7 +84,10 @@ def _iter_union(field_type: Any) -> List[Type[Any]]:
 
 def _is_pydantic_model(model: Any) -> TypeGuard[Type[BaseModel]]:
     """Return True if `model` is a Pydantic `BaseModel` class."""
-    return isinstance(model, type) and issubclass(model, BaseModel)
+    try:
+        return issubclass(model, BaseModel)
+    except TypeError:
+        return False
 
 
 def _collect_fields(


### PR DESCRIPTION
I encountered this very specific issue while trying to integrate pydanclick in [scim2-cli](https://scim2-cli.readthedocs.io). Without this PR, the following code crashes with python 3.10, which is a simplified version of my real usecase that involves [this `Reference` class](https://github.com/yaal-coop/scim2-models/blob/42fff5db0ad1bcd28d834ddc44db2984f260c5da/scim2_models/base.py#L45-L77).

```python
import click

from collections import UserString
from pydanclick import from_pydantic
from pydantic import BaseModel
from pydantic import GetCoreSchemaHandler
from pydantic_core import core_schema
from typing import Any
from typing import Generic
from typing import TypeVar


T = TypeVar("T")


class Reference(UserString, Generic[T]):
    @classmethod
    def __get_pydantic_core_schema__(
        cls,
        _source: type[Any],
        _handler: GetCoreSchemaHandler,
    ) -> core_schema.CoreSchema:
        return core_schema.no_info_after_validator_function(
            cls._validate, core_schema.str_schema()
        )

    @classmethod
    def _validate(cls, input_value: str, /) -> str:
        return input_value


class Foobar(BaseModel):
    ref: Reference[str]


@click.command()
@from_pydantic(Foobar)
def cli(foobar: Foobar):
    print(foobar.ref)
```

```python
Traceback (most recent call last):
  File "/home/eloi/dev/yaal/scim2-cli/foobar.py", line 38, in <module>
    @from_pydantic(Foobar)
  File "/home/eloi/.cache/pypoetry/virtualenvs/scim2-cli-KsA89t9a-py3.10/lib/python3.10/site-packages/pydanclick/main.py", line 51, in from_pydantic
    options, validator = convert_to_click(
  File "/home/eloi/.cache/pypoetry/virtualenvs/scim2-cli-KsA89t9a-py3.10/lib/python3.10/site-packages/pydanclick/model/model_conversion.py", line 66, in convert_to_click
    fields = collect_fields(
  File "/home/eloi/.cache/pypoetry/virtualenvs/scim2-cli-KsA89t9a-py3.10/lib/python3.10/site-packages/pydanclick/model/field_collection.py", line 64, in collect_fields
    return [
  File "/home/eloi/.cache/pypoetry/virtualenvs/scim2-cli-KsA89t9a-py3.10/lib/python3.10/site-packages/pydanclick/model/field_collection.py", line 64, in <listcomp>
    return [
  File "/home/eloi/.cache/pypoetry/virtualenvs/scim2-cli-KsA89t9a-py3.10/lib/python3.10/site-packages/pydanclick/model/field_collection.py", line 106, in _collect_fields
    yield from _collect_fields(
  File "/home/eloi/.cache/pypoetry/virtualenvs/scim2-cli-KsA89t9a-py3.10/lib/python3.10/site-packages/pydanclick/model/field_collection.py", line 117, in _collect_fields
    if _is_pydantic_model(annotation):
  File "/home/eloi/.cache/pypoetry/virtualenvs/scim2-cli-KsA89t9a-py3.10/lib/python3.10/site-packages/pydanclick/model/field_collection.py", line 87, in _is_pydantic_model
    return isinstance(model, type) and issubclass(model, BaseModel)
  File "/usr/lib/python3.10/abc.py", line 123, in __subclasscheck__
    return _abc_subclasscheck(cls, subclass)
TypeError: issubclass() arg 1 must be a class
```

The error is solved if:
- `Reference` is not generic
- `Reference` does not inherit from `UserString`
- using python 3.11+

This is due to the `issubclass` call in:
https://github.com/felix-martel/pydanclick/blob/3dd27be9930044b1b65ac61728a771eca00e2f9d/pydanclick/model/field_collection.py#L85-L87

With python 3.10 `isinstance(Reference[str], type)` is `True` but `False` for 3.11 and upper.

I don't really know what is going on deep in Python, but adopting a [*Easier to ask forgiveness than permission*](https://realpython.com/python-lbyl-vs-eafp/#the-easier-to-ask-forgiveness-than-permission-eafp-style) here solves the issue in a relatively simple way.