### PR TITLE
Allow unpacking of lists of submodels

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,57 @@ Options:
   --help                      Show this message and exit.
 ```
 
+### Unpacking (experimental)
+
+_Unpacking_ provides a simpler API when working with list of submodels.
+
+Consider the following example:
+
+```python
+class Author:
+    name: str
+    primary: bool = False
+
+
+class Book:
+    title: str
+    authors: list[Author]
+
+@click.command()
+@from_pydantic(Book, unpack_list=True)
+def cli(book: Book):
+    pass
+```
+
+By default, this would create two command-line arguments `--title` and `--authors`. Since `authors` has a complex type, it should be passed as a JSON string (e.g. `--authors '[{"authors": {"name": "Alice", "primary": true}, {"name": "Bob"}]'). Using `unpacked_list`will instead "unpack" the nested field`name`into the main namespace: this new argument is called`--authors-name` and can be specified multiple time, for example:
+
+```shell
+python cli.py --authors-name Alice --authors-primary --authors-name Bob
+```
+
+would create:
+
+```python
+Book(authors=[Author(name="Alice", primary=True), Author(name="Bob")])
+```
+
+Note that you must always specify objects with optional arguments _before_ objects without them. For example, the following command would make `Bob` the primary author, not `Alice`:
+
+```shell
+python cli.py --authors-name Bob --authors-name Alice --authors-primary
+```
+
+_(Why? Because under the hood, arguments are collected per field `{"name": [Bob, Alice], "primary": [True]}`, and relative placement between fields cannot be accessed.)_
+
+When in doubt, you can simply specify all arguments:
+
+```shell
+python cli.py --authors-name Bob --no-authors-primary --authors-name Alice --authors-primary
+```
+
+This API is experimental and will not work in complex cases (deeply nested lists, lists of union, and much more).
+See issue [#20](https://github.com/felix-martel/pydanclick/issues/20) for context and details.
+
 <!-- --8<-- [end:features] -->
 
 ## API Reference

--- a/pydanclick/main.py
+++ b/pydanclick/main.py
@@ -23,6 +23,7 @@ def from_pydantic(
     docstring_style: Literal["google", "numpy", "sphinx"] = "google",
     extra_options: Optional[Dict[str, _ParameterKwargs]] = None,
     ignore_unsupported: Optional[bool] = False,
+    unpack_list: bool = False,
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """Decorator to add fields from a Pydantic model as options to a Click command.
 
@@ -39,6 +40,9 @@ def from_pydantic(
         docstring_style: style of the docstring (`google`, `numpy` or `sphinx`). Ignored if `parse_docstring` is False
         extra_options: a mapping from field names to a dictionary of options passed to the `click.option()` function
         ignore_unsupported: ignore unsupported model fields instead of raising
+        unpack_list: if True, a list of nested models (e.g. `list[Foo]`) will be yield one command-line option for each
+            field in the nested model. Each field can be specified multiple times. This API is experimental.
+
 
     Returns:
         a decorator that adds options to a function
@@ -60,6 +64,7 @@ def from_pydantic(
         docstring_style=docstring_style,
         extra_options=extra_options,
         ignore_unsupported=ignore_unsupported,
+        unpack_list=unpack_list,
     )
 
     def wrapper(f: Callable[..., T]) -> Callable[..., T]:

--- a/pydanclick/model/field_collection.py
+++ b/pydanclick/model/field_collection.py
@@ -31,7 +31,7 @@ class _Field:
     field_info: FieldInfo
     documentation: Optional[str] = None
     parents: Tuple[FieldName, ...] = ()
-    unpacked_from: DottedFieldName | None = None
+    unpacked_from: Union[DottedFieldName, None] = None
 
     @property
     def is_boolean_flag(self) -> bool:

--- a/pydanclick/model/field_collection.py
+++ b/pydanclick/model/field_collection.py
@@ -23,6 +23,7 @@ class _Field:
         field_info: Pydantic `FieldInfo` object representing the field
         documentation: help string for the field, if available
         parents: list of parent names for the field
+        unpacked_from: name of the parent of this field. Only set for fields that are nested inside a list
     """
 
     name: FieldName
@@ -30,11 +31,17 @@ class _Field:
     field_info: FieldInfo
     documentation: Optional[str] = None
     parents: Tuple[FieldName, ...] = ()
+    unpacked_from: DottedFieldName | None = None
 
     @property
     def is_boolean_flag(self) -> bool:
         """Return True if the field represents boolean values."""
         return self.field_info.annotation is bool
+
+    @property
+    def multiple(self) -> bool:
+        """Return True if the field accepts multiple values."""
+        return self.unpacked_from is not None
 
 
 def collect_fields(
@@ -42,6 +49,7 @@ def collect_fields(
     excluded_fields: Iterable[DottedFieldName] = frozenset(),
     parse_docstring: bool = True,
     docstring_style: Literal["google", "numpy", "sphinx"] = "google",
+    unpack_list: bool = False,
 ) -> List[_Field]:
     """Collect fields (including nested ones) from a Pydantic model.
 
@@ -51,6 +59,8 @@ def collect_fields(
             all its parent names, separated by dots
         parse_docstring: if True, parse the model docstring and extract document for each field
         docstring_style: docstring style of the model. Ignored if `parse_docstring=False`
+        unpack_list: if True, lists of submodel will yield the list of fields of said submodule (where each field can
+            be specified multiple times)
 
     Returns:
         a mapping from field dotted names to field objects. Each field object contains the Pydantic `FieldInfo`, as well
@@ -63,7 +73,9 @@ def collect_fields(
         excluded_pattern = None
     return [
         option
-        for option in _collect_fields(obj, docstring_style=docstring_style, parse_docstring=parse_docstring)
+        for option in _collect_fields(
+            obj, docstring_style=docstring_style, parse_docstring=parse_docstring, unpack_list=unpack_list
+        )
         if excluded_pattern is None or not re.search(excluded_pattern, option.dotted_name)
     ]
 
@@ -97,6 +109,7 @@ def _collect_fields(
     documentation: Optional[str] = None,
     parse_docstring: bool = True,
     docstring_style: Literal["google", "numpy", "sphinx"] = "google",
+    unpack_list: bool = False,
 ) -> Iterable[_Field]:
     """Recursively iterate over fields from a Pydantic model."""
     if _is_pydantic_model(obj) or _is_pydantic_model(getattr(obj, "annotation", None)):
@@ -112,10 +125,30 @@ def _collect_fields(
                 parents=(*parents, field_name),
                 documentation=documentation,
                 parse_docstring=parse_docstring,
+                unpack_list=unpack_list,
             )
     elif isinstance(obj, FieldInfo):
         if not name:
             raise ValueError(f"Can't automatically infer a name from a field: {obj}")
+        dotted_name = DottedFieldName(".".join(parents))
+        if (
+            unpack_list
+            and get_origin(obj.annotation) is list
+            and len(args := get_args(obj.annotation)) == 1
+            and _is_pydantic_model(args[0])
+        ):
+            for collected_field in _collect_fields(
+                args[0],
+                name=name,
+                parents=parents,
+                documentation=documentation,
+                parse_docstring=parse_docstring,
+                # Cannot have unpacked model inside another unpacked model (unspecified behavior)
+                unpack_list=False,
+            ):
+                collected_field.unpacked_from = dotted_name
+                yield collected_field
+            return
         for annotation in _iter_union(obj.annotation):
             if _is_pydantic_model(annotation):
                 yield from _collect_fields(
@@ -124,9 +157,9 @@ def _collect_fields(
                     parents=parents,
                     documentation=documentation,
                     parse_docstring=parse_docstring,
+                    unpack_list=unpack_list,
                 )
         # TODO: exclude base models from the union
-        dotted_name = DottedFieldName(".".join(parents))
         yield _Field(
             name=name,
             dotted_name=dotted_name,

--- a/pydanclick/model/field_conversion.py
+++ b/pydanclick/model/field_conversion.py
@@ -59,6 +59,7 @@ def convert_fields_to_options(
                 documentation=field.field_info.description or field.documentation,
                 short_name=shorten.get(field.dotted_name, None),
                 option_kwargs=extra_options.get(field.dotted_name, {}),
+                multiple=field.multiple,
             )
             options.append(option)
             qualified_names[argument_name] = field.dotted_name
@@ -147,6 +148,7 @@ def _get_option_from_field(
     documentation: Optional[str] = None,
     short_name: Optional[str] = None,
     option_kwargs: Optional[_ParameterKwargs] = None,
+    multiple: bool = False,
 ) -> click.Option:
     """Convert a Pydantic field to a Click option.
 
@@ -158,6 +160,7 @@ def _get_option_from_field(
         documentation: help string for the option
         short_name: short name of the option (one dash and one letter)
         option_kwargs: extra options to pass to `click.option`
+        multiple: if field can be specified multiple times
 
     Returns:
         `click.Option` object
@@ -167,9 +170,10 @@ def _get_option_from_field(
         param_decls.append(short_name)
     kwargs: _ParameterKwargs = {
         "type": _get_type_from_field(field_info),
-        "default": _get_default_value_from_field(field_info),
+        "default": _get_default_value_from_field(field_info) if not multiple else [],
         "required": field_info.is_required(),
         "help": documentation,
+        "multiple": multiple,
     }
     if option_kwargs is not None:
         kwargs.update(option_kwargs)

--- a/pydanclick/model/validation.py
+++ b/pydanclick/model/validation.py
@@ -8,7 +8,8 @@ Validation involves the following steps:
 - pass the nested representation to the `model_validate` method of the Pydantic model
 """
 
-from typing import Any, Dict, Type
+from itertools import zip_longest
+from typing import Any, Dict, Iterable, List, Set, Type
 
 from pydantic import BaseModel
 from typing_extensions import TypeVar
@@ -21,7 +22,10 @@ K = TypeVar("K", bound=str)
 
 
 def model_validate_kwargs(
-    kwargs: Dict[ArgumentName, Any], model: Type[M], qualified_names: Dict[ArgumentName, DottedFieldName]
+    kwargs: Dict[ArgumentName, Any],
+    model: Type[M],
+    qualified_names: Dict[ArgumentName, DottedFieldName],
+    unpacked_names: Set[DottedFieldName],
 ) -> M:
     """Instantiate `model` for keyword arguments.
 
@@ -43,7 +47,22 @@ def model_validate_kwargs(
     """
     flat_model = _parse_options(qualified_names, kwargs)
     raw_model = _unflatten_dict(flat_model)
+    for name in unpacked_names & raw_model.keys():
+        raw_model[name] = _pack_dict(raw_model[name])
+        # There is no way to distinguish between passing an empty list and not passing anything: here, we assume empty
+        # means nothing was passed, and we rely on Pydantic validation to either fail (if argument is mandatory) or
+        # provide a default value (if there is one). To pass an empty list explicitly, turn off unpacking and pass '[]'
+        if not raw_model[name]:
+            del raw_model[name]
     return model.model_validate(raw_model)
+
+
+def _pack_dict(d: Dict[K, Iterable[V]]) -> List[Dict[K, Any]]:
+    unset = object()
+    packed_dict = []
+    for values in zip_longest(*d.values(), fillvalue=unset):
+        packed_dict.append({key: value for key, value in zip(d, values) if value is not unset})
+    return packed_dict
 
 
 def _unflatten_dict(d: Dict[K, V], sep: str = ".") -> Dict[str, Any]:

--- a/pydanclick/model/validation.py
+++ b/pydanclick/model/validation.py
@@ -41,6 +41,8 @@ def model_validate_kwargs(
         kwargs: mapping from argument name to their values
         model: Pydantic model to instantiate
         qualified_names: a mapping from argument names to corresponding dotted field names
+        unpacked_names: list of (dotted) field names to unpack, i.e. that are represented as a dict of lists and should
+            be turned as a list of dicts
 
     Returns:
         an instance of `model` with the provided values

--- a/tests/base_models.py
+++ b/tests/base_models.py
@@ -1,4 +1,4 @@
-from typing import List, Literal
+from typing import List, Literal, Union
 
 from pydantic import BaseModel, Field
 
@@ -29,6 +29,16 @@ class Foos(BaseModel):
 
 class OptionalFoos(BaseModel):
     foos: List[Foo] = Field(default_factory=list)
+
+
+class UnionFoos(BaseModel):
+    foobazs: List[Union[Foo, Baz]]
+    foos: List[Foo]
+
+
+class MultipleFoos(BaseModel):
+    foos: List[Foo]
+    bazs: List[Baz]
 
 
 class NestedFoos(BaseModel):

--- a/tests/base_models.py
+++ b/tests/base_models.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import List, Literal
 
 from pydantic import BaseModel, Field
 
@@ -21,3 +21,15 @@ class Bar(BaseModel):
 class Obj(BaseModel):
     foo: Foo = Field(default_factory=Foo)
     bar: Bar = Field(default_factory=Bar)
+
+
+class Foos(BaseModel):
+    foos: List[Foo]
+
+
+class OptionalFoos(BaseModel):
+    foos: List[Foo] = Field(default_factory=list)
+
+
+class NestedFoos(BaseModel):
+    nested: Foos

--- a/tests/test_field_collection.py
+++ b/tests/test_field_collection.py
@@ -1,5 +1,5 @@
 from pydanclick.model.field_collection import _Field, collect_fields
-from tests.base_models import Bar, Baz, Foo, Obj
+from tests.base_models import Bar, Baz, Foo, Foos, Obj
 
 
 def test_collect_fields():
@@ -17,3 +17,28 @@ def test_collect_fields_with_exclude():
     fields = collect_fields(Obj, excluded_fields=["foo", "bar.b"])
     assert {field.dotted_name for field in fields} == {"bar.a", "bar.baz.c"}
     # TODO: test docstring parsing
+
+
+def test_collect_fields_without_unpack_list():
+    fields = collect_fields(Foos, unpack_list=False)
+    assert fields == [_Field(name="foos", dotted_name="foos", field_info=Foos.model_fields["foos"], parents=("foos",))]
+
+
+def test_collect_fields_with_unpack_list():
+    fields = collect_fields(Foos, unpack_list=True)
+    assert fields == [
+        _Field(
+            name="a",
+            dotted_name="foos.a",
+            field_info=Foo.model_fields["a"],
+            parents=("foos", "a"),
+            unpacked_from="foos",
+        ),
+        _Field(
+            name="b",
+            dotted_name="foos.b",
+            field_info=Foo.model_fields["b"],
+            parents=("foos", "b"),
+            unpacked_from="foos",
+        ),
+    ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,10 +3,10 @@ from typing import Dict, List
 import click
 import pytest
 from click.testing import CliRunner
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from pydanclick import from_pydantic
-from tests.base_models import Bar, Baz, Foo, Obj
+from tests.base_models import Bar, Baz, Foo, Foos, NestedFoos, Obj, OptionalFoos
 
 
 class Config(BaseModel):
@@ -60,3 +60,44 @@ def test_from_pydantic_with_invalid_call():
         @from_pydantic("foo")
         def cli(foo):
             pass
+
+
+def test_unpack_list():
+    @click.command()
+    @from_pydantic(Foos, unpack_list=True)
+    def cli(foos: Foos):
+        click.echo(foos.model_dump_json(indent=2))
+
+    result = CliRunner().invoke(cli, ["--foos-a", "2"])
+    assert Foos.model_validate_json(result.output) == Foos(foos=[Foo(a=2)])
+
+    result = CliRunner().invoke(cli, ["--foos-a", "2", "--no-foos-b"])
+    assert Foos.model_validate_json(result.output) == Foos(foos=[Foo(a=2, b=False)])
+
+    result = CliRunner().invoke(cli, ["--foos-a", "2", "--foos-a", "3"])
+    assert Foos.model_validate_json(result.output) == Foos(foos=[Foo(a=2), Foo(a=3)])
+
+    with pytest.raises(ValidationError):
+        CliRunner().invoke(cli, [], catch_exceptions=False)
+
+
+def test_unpack_list_with_default_factory():
+    @click.command()
+    @from_pydantic("foos", OptionalFoos, unpack_list=True)
+    def cli(foos: OptionalFoos):
+        click.echo(foos.model_dump_json(indent=2))
+
+    result = CliRunner().invoke(cli, [], catch_exceptions=False)
+    assert OptionalFoos.model_validate_json(result.output) == OptionalFoos(foos=[])
+
+
+@pytest.mark.xfail(reason="`model_validate_kwargs()` doesn't support nested fields")
+def test_unpack_list_with_nested_list():
+    @click.command()
+    @from_pydantic("nested", NestedFoos, unpack_list=True)
+    def cli(nested: NestedFoos):
+        click.echo(nested.model_dump_json(indent=2))
+
+    result = CliRunner().invoke(cli, ["--nested-foos-a", "2", "--no-nested-foos-b", "--nested-foos-a", "3"])
+    assert result.exit_code == 0
+    assert NestedFoos.model_validate_json(result.output) == NestedFoos(nested=Foos(foos=[Foo(a=2, b=False), Foo(a=3)]))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,19 @@
+import pytest
+
+from pydanclick.model.validation import _pack_dict
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_value",
+    [
+        # Same length
+        ({"a": [1, 2], "b": ["a", "b"]}, [{"a": 1, "b": "a"}, {"a": 2, "b": "b"}]),
+        # Different lengths
+        ({"a": [1, 2], "b": ["a"]}, [{"a": 1, "b": "a"}, {"a": 2}]),
+        # One empty
+        ({"a": [1, 2], "b": []}, [{"a": 1}, {"a": 2}]),
+    ],
+)
+def test__pack_dict(input_value, expected_value):
+    packed_value = _pack_dict(input_value)
+    assert packed_value == expected_value


### PR DESCRIPTION
A first attempt to solve #20.

## Usage

This code:

```python
class Email(BaseModel):
  value: str
  primary: bool = False

class User(BaseModel):
  emails: list[Email]


@click.command()
@from_pydantic(User, unpack_list=True):
def cli(user: User):
  ...
```

will allow the following call:

```shell
python cli.py --emails-value alice@mail.com --primary --emails-value bob@mail.com
```

## Todo

- [ ] Add support for lists nested inside submodels
- [ ] Write doc
- [ ] Think of a basic set of edge cases and test them

## Limitations

1. Behavior is unspecified in many cases (list of union, union of list, complex constraints on nested fields, and many more). I don't think I can come up with a fully satisfying behavior for all cases, so this feature will probably stay on a best-effort basis, deactivated by default and only activated if `unpack_list=True` (or whatever the argument name I end up with).
2. We don't have access to argument positions inside the Click command (at least not easily), so we can't distinguish between these two commands:
```shell
python cli.py --emails-value alice@mail.com --primary --emails-value bob@mail.com
python cli.py --emails-value alice@mail.com --emails-value bob@mail.com --primary 
```

To mark `bob@mail.com` as primary, you'd have to do:
```shell
python cli.py --emails-value alice@mail.com --no-primary --emails-value bob@mail.com --primary
```
or change the order between `alice` and `bob`.

_(Basically what happens under the hood is that all arguments for a given field are collected inside a list, and these lists are zipped together (in the example above `["alice@mail.com", "bob@mail.com"], [primary, <unset>]`))_
