### PR TITLE
Use `repr` when formatting option help.

### DIFF
--- a/pydanclick/model/type_conversion.py
+++ b/pydanclick/model/type_conversion.py
@@ -70,7 +70,7 @@ class PydanclickDefault:
         return bool(self._default)
 
     def __repr__(self) -> Any:
-        return self._default.__repr__()
+        return repr(self._default)
 
 
 class PydanclickDefaultCallable(PydanclickDefault):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -86,3 +86,13 @@ def test_complex_types_example(args, expected_results):
     result = runner.invoke(complex_types.cli, ["--image", "foo", *args])
     assert result.exit_code == 0
     assert json.loads(result.output) == {"image": "foo", "mounts": [], "ports": {}, **expected_results}
+
+
+def test_complex_types_example_help():
+    """Ensure the 'complex_types' examples help works."""
+    for o in complex_types.cli.params:
+        o.show_default = True
+    runner = CliRunner()
+    result = runner.invoke(complex_types.cli, ["--help"])
+    assert result.exit_code == 0
+    assert "--ports JSON STRING   port binding  [default: <class 'dict'>]" in result.output


### PR DESCRIPTION
Directly invoking `__repr__()` results in:
`TypeError: descriptor '__repr__' of 'dict' object needs an argument` for `Field(default_factory=dict)` when `show_default=True` is used.