### PR TITLE
Various fixes for current `main`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     steps:
       - name: Check out

--- a/pydanclick/model/field_collection.py
+++ b/pydanclick/model/field_collection.py
@@ -117,7 +117,7 @@ def _collect_fields(
         model: type[BaseModel]
         model = obj if _is_pydantic_model(obj) else obj.annotation  # type: ignore[assignment, union-attr]
         docstrings = parse_attribute_documentation(model, docstring_style=docstring_style) if parse_docstring else {}
-        for field_name, field in model.model_fields.items():
+        for field_name, field in model.__pydantic_fields__.items():
             field_name = FieldName(field_name)
             documentation = docstrings.get(field_name, None)
             yield from _collect_fields(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ check_untyped_defs = "True"
 warn_return_any = "True"
 warn_unused_ignores = "True"
 show_error_codes = "True"
+plugins = ['pydantic.mypy']
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
With the intent of having a green CI on `main`:
- fixes a typo in `main.yml` workflow
- replace the [deprecated `BaseModel.model_fields` (instance property)](https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_fields) by `BaseModel.__pydantic_fields__` (fix the MyPy error)
- enable the [Pydantic MyPy plugin](https://docs.pydantic.dev/latest/integrations/mypy/) for improved typing handling