### PR TITLE
Fix compatibility for Pydantic <=2.9

### DIFF
--- a/pydanclick/model/field_collection.py
+++ b/pydanclick/model/field_collection.py
@@ -103,6 +103,15 @@ def _is_pydantic_model(model: Any) -> TypeGuard[type[BaseModel]]:
         return False
 
 
+def _get_pydantic_fields(obj: type[BaseModel]) -> dict[str, FieldInfo]:
+    try:
+        # Pydantic >=2.10
+        return obj.__pydantic_fields__  # type: ignore[attr-defined, no-any-return]
+    except AttributeError:
+        # Pydantic <=2.9
+        return obj.model_fields  # type: ignore[attr-defined, no-any-return]
+
+
 def _collect_fields(
     obj: Union[type[BaseModel], FieldInfo],
     name: FieldName = "",  # type: ignore[assignment]
@@ -117,7 +126,7 @@ def _collect_fields(
         model: type[BaseModel]
         model = obj if _is_pydantic_model(obj) else obj.annotation  # type: ignore[assignment, union-attr]
         docstrings = parse_attribute_documentation(model, docstring_style=docstring_style) if parse_docstring else {}
-        for field_name, field in model.__pydantic_fields__.items():
+        for field_name, field in _get_pydantic_fields(model).items():
             field_name = FieldName(field_name)
             documentation = docstrings.get(field_name, None)
             yield from _collect_fields(

--- a/pydanclick/model/field_collection.py
+++ b/pydanclick/model/field_collection.py
@@ -109,7 +109,7 @@ def _get_pydantic_fields(obj: type[BaseModel]) -> dict[str, FieldInfo]:
         return obj.__pydantic_fields__  # type: ignore[attr-defined, no-any-return]
     except AttributeError:
         # Pydantic <=2.9
-        return obj.model_fields  # type: ignore[attr-defined, no-any-return]
+        return obj.model_fields  # type: ignore[attr-defined, no-any-return, return-value]
 
 
 def _collect_fields(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ disallow_any_unimported = "True"
 no_implicit_optional = "True"
 check_untyped_defs = "True"
 warn_return_any = "True"
-warn_unused_ignores = "True"
+warn_unused_ignores = "False"
 show_error_codes = "True"
 plugins = ['pydantic.mypy']
 


### PR DESCRIPTION
#41 introduced a bug with Pydantic 2.9 and before:

```
E   AttributeError: __pydantic_fields__. Did you mean: '__pydantic_fields_set__'?
```
