### PR TITLE
Add support for arbitrary types

### DIFF
--- a/pydanclick/model/model_conversion.py
+++ b/pydanclick/model/model_conversion.py
@@ -83,6 +83,7 @@ def convert_to_click(
         shorten=cast(Optional[dict[DottedFieldName, OptionName]], shorten),
         extra_options=cast(dict[DottedFieldName, _ParameterKwargs], extra_options),
         ignore_unsupported=ignore_unsupported,
+        model_config=model.model_config,
     )
     unpacked_names = {field.unpacked_from for field in fields if field.unpacked_from is not None}
     validator = functools.partial(


### PR DESCRIPTION
Attributes with arbitrary types (e.g. `np.ndarray` or `torch.Tensor`) are now supported by Pydanclick. Since non-standard types are passed as JSON, these arbitrary types must include a custom JSON validator, e.g.

```py
class Params(BaseModel):
   model_config = ConfigDict(arbitrary_types_allowed=True)

   weights: Annotated[np.ndarray, BeforeValidator(np.array)]


@click.command()
@from_pydantic(Params)
def cli(params: Params):
   print(params.weights.shape)
```

Which could be used as `--params '[[1, 2], [3, 4]]'`.


To support this, I made the following changes:

- propagate `model_config` from model class down to `type_conversion._create_custom_type()`
- use annotations (thus, validators) from field to `type_conversion._create_custom_type()`

Closes #42 