### PR TITLE
Resolve validation aliases

### DIFF
--- a/pydanclick/model/validation.py
+++ b/pydanclick/model/validation.py
@@ -13,13 +13,44 @@ from itertools import zip_longest
 from typing import Any
 
 from pydantic import BaseModel
+from pydantic.fields import FieldInfo
 from typing_extensions import TypeVar
 
+from pydanclick.model.field_collection import _get_pydantic_fields, _is_pydantic_model
 from pydanclick.types import ArgumentName, DottedFieldName
 
 M = TypeVar("M", bound=BaseModel)
 V = TypeVar("V")
 K = TypeVar("K", bound=str)
+
+
+def _resolve_validation_aliases(data: dict[str, Any], model: type[BaseModel]) -> dict[str, Any]:
+    """Apply validation aliases recursively to a nested data dictionary.
+
+    Args:
+        data: nested dictionary with field names as keys
+        model: Pydantic model type to get field information from
+
+    Returns:
+        nested dictionary with field names replaced by their validation aliases where applicable
+    """
+    fields = _get_pydantic_fields(model)
+    validation_aliases = {}
+    for field_name, field_info in fields.items():
+        if field_info.validation_alias is not None:
+            validation_aliases[field_name] = field_info.validation_alias
+
+    result = {}
+    for key, value in data.items():
+        alias_key = validation_aliases.get(key, key)
+
+        if isinstance(value, dict) and key in fields:
+            field_info = fields[key]
+            if isinstance(field_info, FieldInfo) and _is_pydantic_model(field_info.annotation):
+                value = _resolve_validation_aliases(value, field_info.annotation)
+
+        result[alias_key] = value
+    return result
 
 
 def model_validate_kwargs(
@@ -57,6 +88,9 @@ def model_validate_kwargs(
         # provide a default value (if there is one). To pass an empty list explicitly, turn off unpacking and pass '[]'
         if not raw_model[name]:
             del raw_model[name]
+
+    raw_model = _resolve_validation_aliases(raw_model, model)
+
     return model.model_validate(raw_model)
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,9 @@
+import json
+
 import click
 import pytest
 from click.testing import CliRunner
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 from pydanclick import from_pydantic
 from tests.base_models import Bar, Baz, Foo, Foos, MultipleFoos, NestedFoos, Obj, OptionalFoos, UnionFoos
@@ -125,3 +127,48 @@ def test_unpack_list_with_nested_list():
     result = CliRunner().invoke(cli, ["--nested-foos-a", "2", "--no-nested-foos-b", "--nested-foos-a", "3"])
     assert result.exit_code == 0
     assert NestedFoos.model_validate_json(result.output) == NestedFoos(nested=Foos(foos=[Foo(a=2, b=False), Foo(a=3)]))
+
+
+def test_validation_alias_simple():
+    """Test that validation_alias works for simple models."""
+
+    class ModelWithAlias(BaseModel):
+        field_with_alias: str = Field(..., validation_alias="field_alias")
+        field_without_alias: str
+
+    @click.command()
+    @from_pydantic("model", ModelWithAlias)
+    def cli(model: ModelWithAlias):
+        click.echo(model.model_dump_json())
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--field-with-alias", "value1", "--field-without-alias", "value2"])
+    assert result.exit_code == 0
+
+    output_data = json.loads(result.output)
+    assert output_data["field_with_alias"] == "value1"
+    assert output_data["field_without_alias"] == "value2"
+
+
+def test_validation_alias_nested():
+    """Test that validation_alias works for nested models."""
+
+    class NestedModel(BaseModel):
+        inner_field: str = Field(..., validation_alias="inner_alias")
+
+    class ParentModel(BaseModel):
+        name: str
+        nested: NestedModel
+
+    @click.command()
+    @from_pydantic("parent", ParentModel)
+    def cli(parent: ParentModel):
+        click.echo(parent.model_dump_json())
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--name", "parent_name", "--nested-inner-field", "nested_value"])
+    assert result.exit_code == 0
+
+    output_data = json.loads(result.output)
+    assert output_data["name"] == "parent_name"
+    assert output_data["nested"]["inner_field"] == "nested_value"


### PR DESCRIPTION
Resolve validation aliases:

```python
  class Model(BaseModel):
      field: str = Field(..., validation_alias="field_alias")

  @click.command()
  @from_pydantic(Model)
  def cli(model: Model):
      click.echo(model.field)

  # Now works: python script.py --field value
```

Fixes #27 